### PR TITLE
[12/28] AlarmManager를 활용한 이벤트 알리미 최초 설정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         applicationId = "com.bodan.maplecalendar"
-        minSdk = 26
+        minSdk = 28
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"
@@ -65,8 +65,10 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
 
     implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
-    implementation("com.google.firebase:firebase-analytics")
+    implementation("com.google.firebase:firebase-analytics-ktx")
     implementation("com.google.firebase:firebase-database-ktx")
+    implementation("com.google.firebase:firebase-messaging-ktx")
+    implementation("androidx.work:work-runtime-ktx:2.9.0")
 
     implementation("io.coil-kt:coil:2.0.0-rc03")
 
@@ -78,7 +80,9 @@ dependencies {
     implementation("com.squareup.moshi:moshi-kotlin:1.9.0")
 
     implementation("com.google.dagger:hilt-android:2.48")
+
     implementation("com.google.firebase:firebase-firestore:24.10.0")
+    implementation("com.google.firebase:firebase-messaging:23.4.0")
     kapt("com.google.dagger:hilt-android-compiler:2.48")
 
     implementation("com.jakewharton.timber:timber:5.0.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,12 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <uses-permission
+        android:name="android.permission.POST_NOTIFICATIONS"
+        android:minSdkVersion="33" />
 
     <application
         android:name=".app.MainApplication"
@@ -21,6 +27,18 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.MapleCalendar"
         tools:targetApi="31">
+        <receiver
+            android:name=".data.broadcastreceiver.MyAlarmReceiver"
+            android:enabled="true"
+            android:exported="false" />
+        <receiver
+            android:name=".data.broadcastreceiver.MyAlarmManagerRestarter"
+            android:enabled="false"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
         <activity
             android:name=".presentation.MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/bodan/maplecalendar/data/broadcastreceiver/MyAlarmManagerRestarter.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/broadcastreceiver/MyAlarmManagerRestarter.kt
@@ -1,0 +1,22 @@
+package com.bodan.maplecalendar.data.broadcastreceiver
+
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+
+class MyAlarmManagerRestarter : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == "android.intent.action.BOOT_COMPLETED") {
+            val alarmManagerRestarter = ComponentName(context, MyAlarmManagerRestarter::class.java)
+
+            context.packageManager.setComponentEnabledSetting(
+                alarmManagerRestarter,
+                PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                PackageManager.DONT_KILL_APP
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/data/broadcastreceiver/MyAlarmProvider.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/broadcastreceiver/MyAlarmProvider.kt
@@ -1,0 +1,92 @@
+package com.bodan.maplecalendar.data.broadcastreceiver
+
+import android.annotation.SuppressLint
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import com.bodan.maplecalendar.app.MainApplication
+import com.bodan.maplecalendar.presentation.MainViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import java.util.Calendar
+
+object MyAlarmProvider {
+
+    private lateinit var pendingIntent: PendingIntent
+
+    @SuppressLint("SimpleDateFormat", "ScheduleExactAlarm")
+    fun callAlarm(alarmCode: Int, viewModel: MainViewModel) {
+        runBlocking {
+            viewModel.setToday().await()
+        }
+        val alarmManager =
+            MainApplication.myContext().getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val receiverIntent =
+            Intent(MainApplication.myContext(), MyAlarmReceiver::class.java).apply {
+                putExtra("alarm_code", alarmCode)
+                putExtra("today", viewModel.todayFormatted.value)
+            }
+
+        pendingIntent = when (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            true -> {
+                PendingIntent.getBroadcast(
+                    MainApplication.myContext(),
+                    alarmCode,
+                    receiverIntent,
+                    PendingIntent.FLAG_IMMUTABLE
+                )
+            }
+
+            false -> {
+                PendingIntent.getBroadcast(
+                    MainApplication.myContext(),
+                    alarmCode,
+                    receiverIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT
+                )
+            }
+        }
+
+        val calendar = Calendar.getInstance().apply {
+            timeInMillis = System.currentTimeMillis()
+            set(Calendar.HOUR_OF_DAY, 0)
+        }
+
+        alarmManager.setExactAndAllowWhileIdle(
+            AlarmManager.RTC_WAKEUP,
+            calendar.timeInMillis,
+            pendingIntent
+        )
+    }
+
+    fun cancelAlarm(alarmCode: Int) {
+        val alarmManager =
+            MainApplication.myContext().getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val receiverIntent =
+            Intent(MainApplication.myContext(), MyAlarmReceiver::class.java)
+
+        pendingIntent = when (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            true -> {
+                PendingIntent.getBroadcast(
+                    MainApplication.myContext(),
+                    alarmCode,
+                    receiverIntent,
+                    PendingIntent.FLAG_IMMUTABLE
+                )
+            }
+
+            false -> {
+                PendingIntent.getBroadcast(
+                    MainApplication.myContext(),
+                    alarmCode,
+                    receiverIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT
+                )
+            }
+        }
+
+        alarmManager.cancel(pendingIntent)
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/data/broadcastreceiver/MyAlarmReceiver.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/broadcastreceiver/MyAlarmReceiver.kt
@@ -1,0 +1,121 @@
+package com.bodan.maplecalendar.data.broadcastreceiver
+
+import android.Manifest
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import com.bodan.maplecalendar.R
+import com.bodan.maplecalendar.data.service.MyAlarmService
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.firestore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+class MyAlarmReceiver : BroadcastReceiver() {
+
+    private lateinit var notificationManager: NotificationManager
+    private lateinit var notificationCompatBuilder: NotificationCompat.Builder
+    private val db = Firebase.firestore
+
+    private suspend fun getEndEvents(today: String): Int {
+        var cnt = 0
+        db.collection("EventList")
+            .get()
+            .addOnSuccessListener { result ->
+                for (element in result) {
+                    if (element.data["eventExp"].toString() == today) {
+                        cnt++
+                    }
+                }
+            }
+        delay(3000L)
+
+        return cnt
+    }
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        notificationManager =
+            context?.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        notificationManager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_HIGH
+            )
+        )
+
+        notificationCompatBuilder = NotificationCompat.Builder(context, CHANNEL_ID)
+
+        val alarmServiceIntent = Intent(context, MyAlarmService::class.java)
+        val requestCode = intent?.extras?.getInt("alarm_code") ?: 1
+        val today = intent?.extras?.getString("today") ?: "2000-00-00"
+
+        CoroutineScope(Dispatchers.Main).launch {
+            val countEndEvents = async(Dispatchers.IO) { getEndEvents(today) }.await()
+
+            Timber.d("이벤트: $countEndEvents")
+
+            val pendingIntent = when (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                true -> {
+                    PendingIntent.getActivity(
+                        context,
+                        requestCode,
+                        alarmServiceIntent,
+                        PendingIntent.FLAG_IMMUTABLE
+                    )
+                }
+
+                false -> {
+                    PendingIntent.getActivity(
+                        context,
+                        requestCode,
+                        alarmServiceIntent,
+                        PendingIntent.FLAG_UPDATE_CURRENT
+                    )
+                }
+            }
+
+            val eventNotification = notificationCompatBuilder
+                .setContentTitle("${countEndEvents}${context.getString(R.string.message_alarm_event_end)}")
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setSmallIcon(R.drawable.ic_bnv_main)
+                .setAutoCancel(true)
+                .setContentIntent(pendingIntent)
+                .setDefaults(Notification.DEFAULT_SOUND)
+                .build()
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                if ((ContextCompat.checkSelfPermission(
+                        context,
+                        Manifest.permission.POST_NOTIFICATIONS
+                    ) == PackageManager.PERMISSION_GRANTED) && (countEndEvents >= 0)
+                ) {
+                    notificationManager.notify(1, eventNotification)
+                }
+            } else {
+                if (countEndEvents >= 0) {
+                    notificationManager.notify(1, eventNotification)
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val CHANNEL_ID = "channel"
+        const val CHANNEL_NAME = "eventAlarmChannel"
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/data/service/MyAlarmService.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/service/MyAlarmService.kt
@@ -1,0 +1,17 @@
+package com.bodan.maplecalendar.data.service
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import java.lang.UnsupportedOperationException
+
+class MyAlarmService : Service() {
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        return START_STICKY
+    }
+
+    override fun onBind(p0: Intent?): IBinder? {
+        throw UnsupportedOperationException("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/setting/PushNotificationFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/setting/PushNotificationFragment.kt
@@ -1,0 +1,71 @@
+package com.bodan.maplecalendar.presentation.setting
+
+import android.Manifest
+import android.os.Build
+import android.os.Bundle
+import android.view.View
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
+import com.bodan.maplecalendar.R
+import com.bodan.maplecalendar.data.broadcastreceiver.MyAlarmProvider.callAlarm
+import com.bodan.maplecalendar.data.broadcastreceiver.MyAlarmProvider.cancelAlarm
+import com.bodan.maplecalendar.databinding.FragmentPushNotificationBinding
+import com.bodan.maplecalendar.presentation.BaseDialogFragment
+import com.bodan.maplecalendar.presentation.MainViewModel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+class PushNotificationFragment :
+    BaseDialogFragment<FragmentPushNotificationBinding>(R.layout.fragment_push_notification) {
+
+    private val viewModel: MainViewModel by activityViewModels()
+    private val requestPermissions =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
+            var flag = true
+            it.entries.forEach { entry ->
+                flag = entry.value
+            }
+            if (flag) {
+                callAlarm(alarmCode = 1, viewModel = viewModel)
+                dismiss()
+            }
+        }
+    private val requestPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) {
+            if (it) {
+                callAlarm(alarmCode = 1, viewModel = viewModel)
+                dismiss()
+            }
+        }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.vm = viewModel
+
+        isCancelable = false
+
+        lifecycleScope.launch {
+            viewModel.settingUiEvent.collectLatest { uiEvent ->
+                if (uiEvent == SettingUiEvent.AllowPushNotification) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        requestPermissions.launch(
+                            arrayOf(
+                                Manifest.permission.POST_NOTIFICATIONS,
+                                Manifest.permission.USE_FULL_SCREEN_INTENT
+                            )
+                        )
+                    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        requestPermission.launch(Manifest.permission.USE_FULL_SCREEN_INTENT)
+                    } else {
+                        callAlarm(alarmCode = 1, viewModel = viewModel)
+                        dismiss()
+                    }
+                } else if (uiEvent == SettingUiEvent.CancelPushNotification) {
+                    cancelAlarm(alarmCode = 1)
+                    dismiss()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/setting/SettingFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/setting/SettingFragment.kt
@@ -46,7 +46,7 @@ class SettingFragment : BaseFragment<FragmentSettingBinding>(R.layout.fragment_s
         }
 
         is SettingUiEvent.SetPushNotification -> {
-
+            findNavController().navigate(R.id.action_setting_to_push_notification)
         }
 
         else -> {}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/setting/SettingUiEvent.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/setting/SettingUiEvent.kt
@@ -19,5 +19,7 @@ sealed class SettingUiEvent {
 
     data object SetPushNotification : SettingUiEvent()
 
-    data object CloseSetPushNotification : SettingUiEvent()
+    data object AllowPushNotification : SettingUiEvent()
+
+    data object CancelPushNotification : SettingUiEvent()
 }

--- a/app/src/main/res/layout/fragment_push_notification.xml
+++ b/app/src/main/res/layout/fragment_push_notification.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="com.bodan.maplecalendar.presentation.MainViewModel" />
+
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="320dp"
+            android:layout_height="wrap_content"
+            android:background="@color/main"
+            tools:context=".presentation.setting.PushNotificationFragment">
+
+            <TextView
+                android:id="@+id/tv_title_push_notification"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:text="@string/text_push_notification"
+                android:textColor="@color/white"
+                android:textSize="24sp"
+                app:layout_constraintBottom_toTopOf="@id/tv_ask_push_notification"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_ask_push_notification"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="32dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/text_ask_push_notification"
+                android:textColor="@color/white"
+                android:textSize="20sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_title_push_notification" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_allow_push_notification"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="32dp"
+                android:layout_marginTop="32dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:background="@color/submit"
+                android:onClick="@{() -> vm.setCallAlarm()}"
+                android:text="@string/text_allow"
+                android:textColor="@color/white"
+                android:textSize="24sp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/btn_not_allow_push_notification"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_ask_push_notification" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_not_allow_push_notification"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="32dp"
+                android:background="@color/alert"
+                android:onClick="@{() -> vm.setCancelAlarm()}"
+                android:text="@string/text_not_allow"
+                android:textColor="@color/white"
+                android:textSize="24sp"
+                app:layout_constraintBottom_toBottomOf="@id/btn_allow_push_notification"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/btn_allow_push_notification"
+                app:layout_constraintTop_toTopOf="@id/btn_allow_push_notification" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
+
+</layout>

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -19,13 +19,13 @@
         tools:context=".presentation.setting.SettingFragment">
 
         <androidx.appcompat.widget.AppCompatButton
-            android:background="@color/main"
             android:id="@+id/btn_nickname_change_setting"
             android:layout_width="0dp"
             android:layout_height="100dp"
             android:layout_marginStart="16dp"
             android:layout_marginTop="192dp"
             android:layout_marginEnd="16dp"
+            android:background="@color/main"
             android:onClick="@{() -> vm.changeCharacterName()}"
             android:text="@string/text_nickname_change"
             android:textColor="@color/white"
@@ -36,11 +36,12 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.appcompat.widget.AppCompatButton
-            android:background="@color/main"
             android:id="@+id/btn_push_notification_setting"
             android:layout_width="0dp"
             android:layout_height="100dp"
             android:layout_marginTop="48dp"
+            android:background="@color/main"
+            android:onClick="@{() -> vm.setPushNotification()}"
             android:text="@string/text_push_notification"
             android:textColor="@color/white"
             android:textSize="32sp"

--- a/app/src/main/res/navigation/nav_graph_main.xml
+++ b/app/src/main/res/navigation/nav_graph_main.xml
@@ -31,11 +31,20 @@
             android:id="@+id/action_setting_to_change_character_name"
             app:destination="@id/fragment_change_character_name" />
 
+        <action
+            android:id="@+id/action_setting_to_push_notification"
+            app:destination="@id/fragment_push_notification" />
+
     </fragment>
 
     <dialog
         android:id="@+id/fragment_change_character_name"
         android:name="com.bodan.maplecalendar.presentation.setting.ChangeCharacterNameFragment"
         android:label="@string/name_menu_change_character_name" />
+
+    <dialog
+        android:id="@+id/fragment_push_notification"
+        android:name="com.bodan.maplecalendar.presentation.setting.PushNotificationFragment"
+        android:label="@string/name_menu_set_push_notification" />
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="message_bad_request">잘못된 요청이에요!</string>
     <string name="message_forbidden">접근이 거부되었어요!</string>
     <string name="message_too_many_requests">요청이 너무 많아요!</string>
+    <string name="message_alarm_event_end">개의 이벤트가 오늘 종료돼요!</string>
 
     <string name="description_character_profile">캐릭터 프로필 이미지</string>
     <!-- TODO: Remove or change this placeholder text -->


### PR DESCRIPTION
## AlarmManager를 활용한 이벤트 알리미 최초 설정
 - BroadcastReceiver로 NotificationManager 생성
 - 싱글톤으로 AlarmManager를 제공하는 클래스 생성
 - AlarmManager는 필요한 데이터를 Intent로 Receiver에 전달하고 정해진 시간마다 NotificationManager가 notify하도록 함.
 - 실행 결과
   <p align="center">
      <img width=150 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/4ce011f2-0d30-4e01-a722-1a878fc8a61f">
   </p>