### PR TITLE
[1/5] 이벤트 DB 읽기 로직 변경, 이벤트 알리미 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.iml
 .gradle
 .idea
+key.jks
+/release
 /local.properties
 /.idea/caches
 /.idea/libraries

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         minSdk = 28
         targetSdk = 34
         versionCode = 1
-        versionName = "0.2.2"
+        versionName = "0.2.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/bodan/maplecalendar/app/MySharedPreferences.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/app/MySharedPreferences.kt
@@ -30,4 +30,12 @@ class MySharedPreferences {
     fun setThemeMode(key: String, defValue: String) {
         preferences.edit().putString(key, defValue).apply()
     }
+
+    fun getAlarm(key: String, defValue: String): String {
+        return preferences.getString(key, defValue).toString()
+    }
+
+    fun setAlarm(key: String, defValue: String) {
+        preferences.edit().putString(key, defValue).apply()
+    }
 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/EventListReader.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/EventListReader.kt
@@ -15,69 +15,7 @@ class EventListReader {
     private val db = Firebase.firestore
     private val formatter = SimpleDateFormat("yyyy-MM-dd")
 
-    suspend fun getEventList(): List<EventItem>? {
-        val newEvents = mutableListOf<EventItem>()
-        var flag = true
-
-        db.collection("EventList")
-            .get()
-            .addOnSuccessListener { result ->
-                for (element in result) {
-                    val newEvent = EventItem(
-                        eventName = element.data["eventName"].toString(),
-                        eventIat = element.data["eventIat"].toString(),
-                        eventExp = element.data["eventExp"].toString(),
-                        eventType = when (element.data["eventType"].toString()) {
-                            "BURNING" -> {
-                                EventType.BURNING
-                            }
-
-                            "COORDINATE" -> {
-                                EventType.COORDINATE
-                            }
-
-                            "PCROOM" -> {
-                                EventType.PCROOM
-                            }
-
-                            "COINSHOP" -> {
-                                EventType.COINSHOP
-                            }
-
-                            "CASH" -> {
-                                EventType.CASH
-                            }
-
-                            "WORLDLEAP" -> {
-                                EventType.WORLDLEAP
-                            }
-
-                            "EVENTWORLD" -> {
-                                EventType.EVENTWORLD
-                            }
-
-                            "HUNTING" -> {
-                                EventType.HUNTING
-                            }
-
-                            else -> {
-                                EventType.DEFAULT
-                            }
-                        },
-                        eventUrl = element.data["eventUrl"].toString(),
-                        eventImage = element.data["eventImage"].toString()
-                    )
-                    newEvents.add(newEvent)
-                }
-            }
-            .addOnFailureListener {
-                flag = false
-            }.await()
-
-        return if (flag) newEvents else null
-    }
-
-    suspend fun getEventListOfDate(specificDay: String): List<EventItem>? {
+    suspend fun getEventList(specificDay: String): List<EventItem>? {
         val newEvents = mutableListOf<EventItem>()
         var flag = true
 
@@ -90,7 +28,7 @@ class EventListReader {
                     val compareToIat = iat?.compareTo(formatter.parse(specificDay))
                     val compareToExp = exp?.compareTo(formatter.parse(specificDay))
                     if ((compareToIat != null) && (compareToExp != null)) {
-                        if ((compareToIat < 0) && (compareToExp > 0)) {
+                        if ((compareToIat <= 0) && (compareToExp >= 0)) {
                             val newEvent = EventItem(
                                 eventName = element.data["eventName"].toString(),
                                 eventIat = element.data["eventIat"].toString(),

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/MainViewModel.kt
@@ -119,7 +119,7 @@ class MainViewModel : ViewModel(), OnDateClickListener, OnEventClickListener {
 
         viewModelScope.launch {
             _calendarUiEvent.emit(CalendarUiEvent.GetEventsOfDate)
-            val eventListOfDate = async { eventListReader.getEventListOfDate(specificDay) }.await()
+            val eventListOfDate = async { eventListReader.getEventList(specificDay) }.await()
             if (eventListOfDate != null) {
                 _eventItemsOfDate.value = eventListOfDate.sortedBy { eventItem ->
                     eventItem.eventExp
@@ -305,7 +305,7 @@ class MainViewModel : ViewModel(), OnDateClickListener, OnEventClickListener {
 
     private fun setEventList() {
         viewModelScope.launch {
-            val eventList = async { eventListReader.getEventList() }.await()
+            val eventList = async { eventListReader.getEventList(todayFormatted.value) }.await()
             if (eventList != null) {
                 _eventItems.value = eventList.sortedBy { eventItem ->
                     eventItem.eventExp

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/broadcastreceiver/MyAlarmManagerRestarter.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/broadcastreceiver/MyAlarmManagerRestarter.kt
@@ -1,16 +1,18 @@
 package com.bodan.maplecalendar.presentation.broadcastreceiver
 
 import android.content.BroadcastReceiver
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
+import com.bodan.maplecalendar.app.MainApplication
+import timber.log.Timber
 
 class MyAlarmManagerRestarter : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action == "android.intent.action.BOOT_COMPLETED") {
+        if ((intent.action == "android.intent.action.BOOT_COMPLETED") &&
+            (MainApplication.mySharedPreferences.getAlarm("eventAlarm", "") == "alarm")) {
             MyAlarmProvider.callAlarm()
+            Timber.d("Alarm")
         }
     }
 }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/broadcastreceiver/MyAlarmProvider.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/broadcastreceiver/MyAlarmProvider.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import com.bodan.maplecalendar.app.MainApplication
+import timber.log.Timber
 import java.util.Calendar
 
 @SuppressLint("SimpleDateFormat", "ScheduleExactAlarm")
@@ -15,6 +16,9 @@ object MyAlarmProvider {
     private lateinit var pendingIntent: PendingIntent
 
     fun callAlarm() {
+        MainApplication.mySharedPreferences.setAlarm("eventAlarm", "alarm")
+        Timber.d("Alarm: ${MainApplication.mySharedPreferences.getAlarm("eventAlarm", "")}")
+
         val alarmManager =
             MainApplication.myContext().getSystemService(Context.ALARM_SERVICE) as AlarmManager
         val receiverIntent =
@@ -46,10 +50,7 @@ object MyAlarmProvider {
             set(Calendar.MINUTE, 0)
             set(Calendar.SECOND, 0)
             set(Calendar.MILLISECOND, 0)
-        }
-
-        if (calendar.before(Calendar.getInstance())) {
-            calendar.add(Calendar.DAY_OF_MONTH, 1)
+            add(Calendar.DAY_OF_MONTH, 1)
         }
 
         val alarmClock = AlarmManager.AlarmClockInfo(calendar.timeInMillis, pendingIntent)
@@ -57,6 +58,9 @@ object MyAlarmProvider {
     }
 
     fun cancelAlarm() {
+        MainApplication.mySharedPreferences.setAlarm("eventAlarm", "")
+        Timber.d("Alarm: ${MainApplication.mySharedPreferences.getAlarm("eventAlarm", "")}")
+
         val alarmManager =
             MainApplication.myContext().getSystemService(Context.ALARM_SERVICE) as AlarmManager
         val receiverIntent =
@@ -81,8 +85,6 @@ object MyAlarmProvider {
                 )
             }
         }
-
-        MainApplication.mySharedPreferences.setAlarm("event_alarm", "")
 
         alarmManager.cancel(pendingIntent)
     }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/setting/PushNotificationFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/setting/PushNotificationFragment.kt
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint
 import android.os.Build
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
@@ -31,6 +32,7 @@ class PushNotificationFragment :
             }
             if (flag) {
                 MyAlarmProvider.callAlarm()
+                Toast.makeText(requireContext(), getString(R.string.message_alarm_call), Toast.LENGTH_LONG).show()
                 dismiss()
             }
         }
@@ -62,10 +64,12 @@ class PushNotificationFragment :
                         )
                     } else {
                         MyAlarmProvider.callAlarm()
+                        Toast.makeText(requireContext(), getString(R.string.message_alarm_call), Toast.LENGTH_LONG).show()
                         dismiss()
                     }
                 } else if (uiEvent == SettingUiEvent.CancelPushNotification) {
                     MyAlarmProvider.cancelAlarm()
+                    Toast.makeText(requireContext(), getString(R.string.message_alarm_cancel), Toast.LENGTH_LONG).show()
                     dismiss()
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,8 +28,8 @@
     <string name="text_power">전투력</string>
     <string name="text_nickname_change">닉네임 변경</string>
     <string name="text_change">변경</string>
-    <string name="text_push_notification">푸시 알림 설정</string>
-    <string name="text_ask_push_notification">푸시 알림을 허용하시겠습니까?</string>
+    <string name="text_push_notification">이벤트 알리미 설정</string>
+    <string name="text_ask_push_notification">이벤트 알림을 받으시겠어요?</string>
     <string name="text_allow">허용</string>
     <string name="text_not_allow">취소</string>
     <string name="text_close">닫기</string>
@@ -44,9 +44,12 @@
     <string name="message_alarm_event_end_check">종료되는 이벤트를 확인해보세요!</string>
     <string name="message_alarm_no_event_end">오늘은 종료되는 이벤트가 없어요!</string>
     <string name="message_alarm_no_event_end_check">일퀘 익몬할 시간이에요!</string>
+    <string name="message_alarm_call">매일 0시에 이벤트 종료 현황을 알려드려요!</string>
+    <string name="message_alarm_cancel">이벤트 알리미를 취소했어요!</string>
 
     <string name="description_character_profile">캐릭터 프로필 이미지</string>
     <string name="description_fab_dark_mode">다크 모드 전환 버튼</string>
+
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
## 2024. 01. 05
  - 이벤트 DB에서 전체 이벤트 읽는 메소드 삭제
  - 이벤트 알리미 구현
    - 매일 00시마다 반복 알림
    - 기기 재부팅 시 알림이 설정되어 있었다면 재부팅 후 알림 재설정

Closes: #12, #13, #19, #20