### PR TITLE
[1/8] 알림 권한 분기 처리

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@
      <img style="width: 200px; margin: 10px" src="https://github.com/littlesam95/MapleCalendar/assets/55424662/d9f54460-12a7-45f5-9904-0e0a881e0ccc">
   </p>
 
+### 구글 플레이스토어에서 내부 테스트 가능
+ - 내부 테스트 접속 링크
+   <p>
+      <img width=150 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/169944e3-eb32-4182-a2b2-70102d1a8735">
+   </p>
+
 ### 📒 주요 기능
 #### 오늘 진행중인 이벤트 확인
  - 이벤트를 클릭하면 공식 홈페이지로 이동된다.
@@ -54,3 +60,10 @@
 | Logging      | Timber                                                                   | 
 
 ### 💬 기술적 고민과 선택
+#### 1. AlarmManager with BroadcastReceiver
+
+
+### References
+<a href="https://www.notion.so/MapleCalendar-93f45dc10b384d749e5ab00950324035?pvs=4">
+  <img alt="Static Badge" src="https://img.shields.io/badge/Notion-%2523000000.svg?style=for-the-badge&logo=notion&logoColor=white&labelColor=black&color=black">
+</a>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,6 +100,8 @@ dependencies {
 
     implementation("com.jakewharton.timber:timber:5.0.1")
 
+    implementation("io.github.ParkSangGwon:tedpermission-normal:3.3.0")
+
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/java/com/bodan/maplecalendar/data/EventListReader.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/EventListReader.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import com.bodan.maplecalendar.presentation.lobby.EventItem
 import com.bodan.maplecalendar.presentation.lobby.EventType
 import com.google.firebase.Firebase
+import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.firestore
 import kotlinx.coroutines.tasks.await
 import java.text.SimpleDateFormat
@@ -11,8 +12,8 @@ import java.text.SimpleDateFormat
 @SuppressLint("SimpleDateFormat")
 class EventListReader {
 
-    private val db = Firebase.firestore
-    private val formatter = SimpleDateFormat("yyyy-MM-dd")
+    private val db: FirebaseFirestore = Firebase.firestore
+    private val formatter: SimpleDateFormat = SimpleDateFormat("yyyy-MM-dd")
 
     suspend fun getEventList(specificDay: String): List<EventItem>? {
         val newEvents = mutableListOf<EventItem>()
@@ -26,6 +27,7 @@ class EventListReader {
                     val exp = formatter.parse(element.data["eventExp"].toString())
                     val compareToIat = iat?.compareTo(formatter.parse(specificDay))
                     val compareToExp = exp?.compareTo(formatter.parse(specificDay))
+
                     if ((compareToIat != null) && (compareToExp != null)) {
                         if ((compareToIat <= 0) && (compareToExp >= 0)) {
                             val newEvent = EventItem(
@@ -92,7 +94,7 @@ class EventListReader {
             .get()
             .addOnSuccessListener { result ->
                 for (element in result) {
-                    if (element.data["eventExp"].toString() == today) {
+                    if (today == element.data["eventExp"].toString()) {
                         countPendingEvents++
                     }
                 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/network/MaplestoryApi.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/network/MaplestoryApi.kt
@@ -2,7 +2,6 @@ package com.bodan.maplecalendar.data.network
 
 import com.bodan.maplecalendar.data.dto.CharacterBasic
 import com.bodan.maplecalendar.data.dto.CharacterOcid
-import com.bodan.maplecalendar.data.dto.CharacterStat
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query

--- a/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRepository.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRepository.kt
@@ -2,7 +2,6 @@ package com.bodan.maplecalendar.data.repository
 
 import com.bodan.maplecalendar.data.dto.CharacterBasicResponse
 import com.bodan.maplecalendar.data.dto.CharacterOcidResponse
-import com.bodan.maplecalendar.data.dto.CharacterStatResponse
 
 interface MaplestoryRepository {
 

--- a/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRepositoryImpl.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRepositoryImpl.kt
@@ -4,7 +4,6 @@ import com.bodan.maplecalendar.data.ResponseStatus
 import com.bodan.maplecalendar.data.NetworkModule
 import com.bodan.maplecalendar.data.dto.CharacterBasicResponse
 import com.bodan.maplecalendar.data.dto.CharacterOcidResponse
-import com.bodan.maplecalendar.data.dto.CharacterStatResponse
 import com.bodan.maplecalendar.data.network.MaplestoryApi
 import timber.log.Timber
 

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/BaseDialogFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/BaseDialogFragment.kt
@@ -7,11 +7,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
+import android.widget.Toast
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.DialogFragment
 
-abstract class BaseDialogFragment<T : ViewDataBinding>(private val layoutId: Int) : DialogFragment() {
+abstract class BaseDialogFragment<T : ViewDataBinding>(private val layoutId: Int) :
+    DialogFragment() {
 
     private var _binding: T? = null
     protected val binding
@@ -35,5 +37,9 @@ abstract class BaseDialogFragment<T : ViewDataBinding>(private val layoutId: Int
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    protected fun showToastMessage(message: String) {
+        Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show()
     }
 }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/MainViewModel.kt
@@ -146,7 +146,8 @@ class MainViewModel : ViewModel(), OnDateClickListener, OnEventClickListener {
             _currentYear.value = dateFormatConverter.todayYear()
             _currentMonth.value = dateFormatConverter.todayMonth()
             _today.value = dateFormatConverter.todayOtherFormatted()
-            currentMinute.value = ((dateFormatConverter.todayHour()) * 60 + dateFormatConverter.todayMinute())
+            currentMinute.value =
+                ((dateFormatConverter.todayHour()) * 60 + dateFormatConverter.todayMinute())
         }
 
         return deferred

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/PowerFormatConverter.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/PowerFormatConverter.kt
@@ -7,8 +7,7 @@ object PowerFormatConverter {
         for (index in power.reversed().indices) {
             if (index == 4) {
                 result += " 만"
-            }
-            else if (index == 8) {
+            } else if (index == 8) {
                 result += " 억"
             }
             result += power.reversed()[index]

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/broadcastreceiver/MyAlarmManagerRestarter.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/broadcastreceiver/MyAlarmManagerRestarter.kt
@@ -4,15 +4,14 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.bodan.maplecalendar.app.MainApplication
-import timber.log.Timber
 
 class MyAlarmManagerRestarter : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         if ((intent.action == "android.intent.action.BOOT_COMPLETED") &&
-            (MainApplication.mySharedPreferences.getAlarm("eventAlarm", "") == "alarm")) {
+            (MainApplication.mySharedPreferences.getAlarm("eventAlarm", "") == "alarm")
+        ) {
             MyAlarmProvider.callAlarm()
-            Timber.d("Alarm")
         }
     }
 }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/broadcastreceiver/MyAlarmReceiver.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/broadcastreceiver/MyAlarmReceiver.kt
@@ -27,13 +27,13 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Calendar
 
-@SuppressLint("ScheduleExactAlarm")
+@SuppressLint("ScheduleExactAlarm", "RestrictedApi")
 class MyAlarmReceiver : BroadcastReceiver() {
 
+    private val eventListReader = EventListReader()
     private lateinit var pendingIntent: PendingIntent
     private lateinit var notificationManager: NotificationManager
     private lateinit var notificationCompatBuilder: NotificationCompat.Builder
-    private val eventListReader = EventListReader()
 
     override fun onReceive(context: Context, intent: Intent) {
         notificationManager =
@@ -107,8 +107,12 @@ class MyAlarmReceiver : BroadcastReceiver() {
 
             when (Build.VERSION.SDK_INT) {
                 !in Build.VERSION_CODES.BASE until Build.VERSION_CODES.TIRAMISU -> {
-                    if (ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
-                        == PackageManager.PERMISSION_GRANTED) {
+                    if (ContextCompat.checkSelfPermission(
+                            context,
+                            Manifest.permission.POST_NOTIFICATIONS
+                        )
+                        == PackageManager.PERMISSION_GRANTED
+                    ) {
                         notificationManager.notify(REQUEST_CODE, eventNotification)
                     }
                 }
@@ -118,7 +122,8 @@ class MyAlarmReceiver : BroadcastReceiver() {
                 }
             }
 
-            val alarmManager = context.getSystemService(AppCompatActivity.ALARM_SERVICE) as AlarmManager
+            val alarmManager =
+                context.getSystemService(AppCompatActivity.ALARM_SERVICE) as AlarmManager
 
             pendingIntent = when (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 true -> {
@@ -154,7 +159,6 @@ class MyAlarmReceiver : BroadcastReceiver() {
         }
     }
 
-    @SuppressLint("RestrictedApi")
     private fun getIcon(): Int {
         return if (ManufacturerUtils.isSamsungDevice()) {
             R.drawable.ic_bnv_main

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/lobby/LobbyFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/lobby/LobbyFragment.kt
@@ -38,7 +38,7 @@ class LobbyFragment : BaseFragment<FragmentLobbyBinding>(R.layout.fragment_lobby
     }
 
     private fun setSwipeRefresh() {
-        with (binding.fragmentLobby) {
+        with(binding.fragmentLobby) {
             setOnRefreshListener {
                 viewModel.initState()
                 binding.fragmentLobby.isRefreshing = false

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/setting/SettingUiState.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/setting/SettingUiState.kt
@@ -5,6 +5,7 @@ data class SettingUiState(
 ) {
     val isSubmitBtnEnable: Boolean = (characterNameValidState == CharacterNameValidState.VALID)
 }
+
 enum class CharacterNameValidState {
     NONE, VALID
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,8 @@
     <string name="message_alarm_event_end_check">종료되는 이벤트를 확인해보세요!</string>
     <string name="message_alarm_no_event_end">오늘은 종료되는 이벤트가 없어요!</string>
     <string name="message_alarm_no_event_end_check">일퀘 익몬할 시간이에요!</string>
+    <string name="message_alarm_need_to_allow_permission_title">권한 허용이 필요해요!</string>
+    <string name="message_alarm_need_to_allow_permission">이벤트 알리미를 사용하려면 알림 권한 허용이 필요해요!</string>
     <string name="message_alarm_call">매일 0시에 이벤트 종료 현황을 알려드려요!</string>
     <string name="message_alarm_cancel">이벤트 알리미를 취소했어요!</string>
 


### PR DESCRIPTION
## 2024. 01. 08
  - TedPermission 라이브러리로 권한 허용을 요청함
    - 권한 허용 시 이벤트 알리미 설정
    - 거절 시 이후부터는 AlertDialog를 띄워 사용자가 직접 알림 권한을 허용하도록 안내함
    - 직접 알림 권한 허용 후 앱으로 돌아가면 바로 이벤트 알리미 설정
  - 코드 개선
  - 알림 권한 허용을 위해 앱 정보 화면을 띄워주면 다음과 같은 에러 메시지가 기록됨. 다만 로직 자체는 문제 없이 작동함.
    <p>
       <img src="https://github.com/littlesam95/MapleCalendar/assets/55424662/50fd40a9-11f6-4d0e-87a5-90e143841d5c">
    </p>