### PR TITLE
[2/21] 캐릭터의 종합 능력치 출력

### DIFF
--- a/app/src/main/java/com/bodan/maplecalendar/presentation/PowerFormatConverter.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/PowerFormatConverter.kt
@@ -1,18 +1,32 @@
 package com.bodan.maplecalendar.presentation
 
+import java.text.DecimalFormat
+
 object PowerFormatConverter {
 
-    fun convertPowerFormat(power: String): String {
+    fun convertPowerFormat(stat: String): String {
         var result = ""
-        for (index in power.reversed().indices) {
+        for (index in stat.reversed().indices) {
             if (index == 4) {
                 result += " 만"
             } else if (index == 8) {
                 result += " 억"
             }
-            result += power.reversed()[index]
+            result += stat.reversed()[index]
         }
 
         return result.reversed()
+    }
+
+    fun convertPercentFormat(stat: String): String {
+        return "${stat}%"
+    }
+
+    fun convertCommaFormat(stat: String): String {
+        return DecimalFormat("#,###").format(stat.toInt())
+    }
+
+    fun convertAttackSpeedFormat(stat: String): String {
+        return "${stat}단계"
     }
 }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/character/CharacterDefaultStatListAdapter.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/character/CharacterDefaultStatListAdapter.kt
@@ -1,0 +1,93 @@
+package com.bodan.maplecalendar.presentation.character
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.bodan.maplecalendar.databinding.ItemCharacterDefaultStatBinding
+import com.bodan.maplecalendar.databinding.ItemCharacterEtcStatBinding
+import com.bodan.maplecalendar.databinding.ItemCharacterMainStatBinding
+import com.bodan.maplecalendar.presentation.character.CharacterUiState.Companion.DEFAULT_STAT_VIEW_TYPE
+import com.bodan.maplecalendar.presentation.character.CharacterUiState.Companion.ETC_STAT_VIEW_TYPE
+import com.bodan.maplecalendar.presentation.character.CharacterUiState.Companion.MAIN_STAT_VIEW_TYPE
+
+class CharacterDefaultStatListAdapter :
+    ListAdapter<CharacterUiState, RecyclerView.ViewHolder>(characterUiStateDiffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return when (viewType) {
+            DEFAULT_STAT_VIEW_TYPE -> CharacterDefaultStatViewHolder(
+                ItemCharacterDefaultStatBinding.inflate(
+                    LayoutInflater.from(parent.context), parent, false
+                )
+            )
+
+            MAIN_STAT_VIEW_TYPE -> CharacterMainStatViewHolder(
+                ItemCharacterMainStatBinding.inflate(
+                    LayoutInflater.from(parent.context), parent, false
+                )
+            )
+
+            else -> CharacterEtcStatViewHolder(
+                ItemCharacterEtcStatBinding.inflate(
+                    LayoutInflater.from(parent.context), parent, false
+                )
+            )
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder.itemViewType) {
+            DEFAULT_STAT_VIEW_TYPE -> (holder as CharacterDefaultStatViewHolder).bind(currentList[position] as CharacterUiState.CharacterDefaultStat)
+
+            MAIN_STAT_VIEW_TYPE -> (holder as CharacterMainStatViewHolder).bind(currentList[position] as CharacterUiState.CharacterMainStat)
+
+            ETC_STAT_VIEW_TYPE -> (holder as CharacterEtcStatViewHolder).bind(currentList[position] as CharacterUiState.CharacterEtcStat)
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when {
+            currentList[position] is CharacterUiState.CharacterDefaultStat -> DEFAULT_STAT_VIEW_TYPE
+
+            currentList[position] is CharacterUiState.CharacterMainStat -> MAIN_STAT_VIEW_TYPE
+
+            else -> ETC_STAT_VIEW_TYPE
+        }
+    }
+
+    companion object {
+        val characterUiStateDiffUtil = object : DiffUtil.ItemCallback<CharacterUiState>() {
+            override fun areItemsTheSame(oldItem: CharacterUiState, newItem: CharacterUiState) =
+                (oldItem.id == newItem.id)
+
+            override fun areContentsTheSame(oldItem: CharacterUiState, newItem: CharacterUiState) =
+                (oldItem == newItem)
+        }
+    }
+
+    class CharacterDefaultStatViewHolder(private val binding: ItemCharacterDefaultStatBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(stat: CharacterUiState.CharacterDefaultStat) {
+            binding.stat = stat
+        }
+    }
+
+    class CharacterMainStatViewHolder(private val binding: ItemCharacterMainStatBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(stat: CharacterUiState.CharacterMainStat) {
+            binding.stat = stat
+        }
+    }
+
+    class CharacterEtcStatViewHolder(private val binding: ItemCharacterEtcStatBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(stat: CharacterUiState.CharacterEtcStat) {
+            binding.stat = stat
+        }
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/character/CharacterEtcStatListAdapter.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/character/CharacterEtcStatListAdapter.kt
@@ -1,0 +1,93 @@
+package com.bodan.maplecalendar.presentation.character
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.bodan.maplecalendar.databinding.ItemCharacterDefaultStatBinding
+import com.bodan.maplecalendar.databinding.ItemCharacterEtcStatBinding
+import com.bodan.maplecalendar.databinding.ItemCharacterMainStatBinding
+import com.bodan.maplecalendar.presentation.character.CharacterUiState.Companion.DEFAULT_STAT_VIEW_TYPE
+import com.bodan.maplecalendar.presentation.character.CharacterUiState.Companion.ETC_STAT_VIEW_TYPE
+import com.bodan.maplecalendar.presentation.character.CharacterUiState.Companion.MAIN_STAT_VIEW_TYPE
+
+class CharacterEtcStatListAdapter :
+    ListAdapter<CharacterUiState, RecyclerView.ViewHolder>(characterUiStateDiffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return when (viewType) {
+            DEFAULT_STAT_VIEW_TYPE -> CharacterDefaultStatViewHolder(
+                ItemCharacterDefaultStatBinding.inflate(
+                    LayoutInflater.from(parent.context), parent, false
+                )
+            )
+
+            MAIN_STAT_VIEW_TYPE -> CharacterMainStatViewHolder(
+                ItemCharacterMainStatBinding.inflate(
+                    LayoutInflater.from(parent.context), parent, false
+                )
+            )
+
+            else -> CharacterEtcStatViewHolder(
+                ItemCharacterEtcStatBinding.inflate(
+                    LayoutInflater.from(parent.context), parent, false
+                )
+            )
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder.itemViewType) {
+            DEFAULT_STAT_VIEW_TYPE -> (holder as CharacterDefaultStatViewHolder).bind(currentList[position] as CharacterUiState.CharacterDefaultStat)
+
+            MAIN_STAT_VIEW_TYPE -> (holder as CharacterMainStatViewHolder).bind(currentList[position] as CharacterUiState.CharacterMainStat)
+
+            ETC_STAT_VIEW_TYPE -> (holder as CharacterEtcStatViewHolder).bind(currentList[position] as CharacterUiState.CharacterEtcStat)
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when {
+            currentList[position] is CharacterUiState.CharacterDefaultStat -> DEFAULT_STAT_VIEW_TYPE
+
+            currentList[position] is CharacterUiState.CharacterMainStat -> MAIN_STAT_VIEW_TYPE
+
+            else -> ETC_STAT_VIEW_TYPE
+        }
+    }
+
+    companion object {
+        val characterUiStateDiffUtil = object : DiffUtil.ItemCallback<CharacterUiState>() {
+            override fun areItemsTheSame(oldItem: CharacterUiState, newItem: CharacterUiState) =
+                (oldItem.id == newItem.id)
+
+            override fun areContentsTheSame(oldItem: CharacterUiState, newItem: CharacterUiState) =
+                (oldItem == newItem)
+        }
+    }
+
+    class CharacterDefaultStatViewHolder(private val binding: ItemCharacterDefaultStatBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(stat: CharacterUiState.CharacterDefaultStat) {
+            binding.stat = stat
+        }
+    }
+
+    class CharacterMainStatViewHolder(private val binding: ItemCharacterMainStatBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(stat: CharacterUiState.CharacterMainStat) {
+            binding.stat = stat
+        }
+    }
+
+    class CharacterEtcStatViewHolder(private val binding: ItemCharacterEtcStatBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(stat: CharacterUiState.CharacterEtcStat) {
+            binding.stat = stat
+        }
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/character/CharacterFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/character/CharacterFragment.kt
@@ -11,13 +11,34 @@ import com.bodan.maplecalendar.presentation.CharacterViewModel
 class CharacterFragment : BaseFragment<FragmentCharacterBinding>(R.layout.fragment_character) {
 
     private val viewModel: CharacterViewModel by activityViewModels()
+    private lateinit var characterDefaultStatListAdapter: CharacterDefaultStatListAdapter
+    private lateinit var characterMainStatListAdapter: CharacterMainStatListAdapter
+    private lateinit var characterEtcStatListAdapter: CharacterEtcStatListAdapter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        initListAdapter()
+        initRecyclerView()
+
         binding.vm = viewModel
+        binding.defaultStatListAdapter = characterDefaultStatListAdapter
+        binding.mainStatListAdapter = characterMainStatListAdapter
+        binding.etcStatListAdapter = characterEtcStatListAdapter
 
         collectLatestFlow(viewModel.characterUiEvent) { handleUiEvent(it) }
+    }
+
+    private fun initListAdapter() {
+        characterDefaultStatListAdapter = CharacterDefaultStatListAdapter()
+        characterMainStatListAdapter = CharacterMainStatListAdapter()
+        characterEtcStatListAdapter = CharacterEtcStatListAdapter()
+    }
+
+    private fun initRecyclerView() {
+        binding.rvDefaultStatCharacter.setHasFixedSize(false)
+        binding.rvMainStatCharacter.setHasFixedSize(false)
+        binding.rvEtcStatCharacter.setHasFixedSize(false)
     }
 
     private fun handleUiEvent(event: CharacterUiEvent) = when (event) {

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/character/CharacterMainStatListAdapter.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/character/CharacterMainStatListAdapter.kt
@@ -1,0 +1,93 @@
+package com.bodan.maplecalendar.presentation.character
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.bodan.maplecalendar.databinding.ItemCharacterDefaultStatBinding
+import com.bodan.maplecalendar.databinding.ItemCharacterEtcStatBinding
+import com.bodan.maplecalendar.databinding.ItemCharacterMainStatBinding
+import com.bodan.maplecalendar.presentation.character.CharacterUiState.Companion.DEFAULT_STAT_VIEW_TYPE
+import com.bodan.maplecalendar.presentation.character.CharacterUiState.Companion.ETC_STAT_VIEW_TYPE
+import com.bodan.maplecalendar.presentation.character.CharacterUiState.Companion.MAIN_STAT_VIEW_TYPE
+
+class CharacterMainStatListAdapter :
+    ListAdapter<CharacterUiState, RecyclerView.ViewHolder>(characterUiStateDiffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return when (viewType) {
+            DEFAULT_STAT_VIEW_TYPE -> CharacterDefaultStatViewHolder(
+                ItemCharacterDefaultStatBinding.inflate(
+                    LayoutInflater.from(parent.context), parent, false
+                )
+            )
+
+            MAIN_STAT_VIEW_TYPE -> CharacterMainStatViewHolder(
+                ItemCharacterMainStatBinding.inflate(
+                    LayoutInflater.from(parent.context), parent, false
+                )
+            )
+
+            else -> CharacterEtcStatViewHolder(
+                ItemCharacterEtcStatBinding.inflate(
+                    LayoutInflater.from(parent.context), parent, false
+                )
+            )
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder.itemViewType) {
+            DEFAULT_STAT_VIEW_TYPE -> (holder as CharacterDefaultStatViewHolder).bind(currentList[position] as CharacterUiState.CharacterDefaultStat)
+
+            MAIN_STAT_VIEW_TYPE -> (holder as CharacterMainStatViewHolder).bind(currentList[position] as CharacterUiState.CharacterMainStat)
+
+            ETC_STAT_VIEW_TYPE -> (holder as CharacterEtcStatViewHolder).bind(currentList[position] as CharacterUiState.CharacterEtcStat)
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when {
+            currentList[position] is CharacterUiState.CharacterDefaultStat -> DEFAULT_STAT_VIEW_TYPE
+
+            currentList[position] is CharacterUiState.CharacterMainStat -> MAIN_STAT_VIEW_TYPE
+
+            else -> ETC_STAT_VIEW_TYPE
+        }
+    }
+
+    companion object {
+        val characterUiStateDiffUtil = object : DiffUtil.ItemCallback<CharacterUiState>() {
+            override fun areItemsTheSame(oldItem: CharacterUiState, newItem: CharacterUiState) =
+                (oldItem.id == newItem.id)
+
+            override fun areContentsTheSame(oldItem: CharacterUiState, newItem: CharacterUiState) =
+                (oldItem == newItem)
+        }
+    }
+
+    class CharacterDefaultStatViewHolder(private val binding: ItemCharacterDefaultStatBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(stat: CharacterUiState.CharacterDefaultStat) {
+            binding.stat = stat
+        }
+    }
+
+    class CharacterMainStatViewHolder(private val binding: ItemCharacterMainStatBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(stat: CharacterUiState.CharacterMainStat) {
+            binding.stat = stat
+        }
+    }
+
+    class CharacterEtcStatViewHolder(private val binding: ItemCharacterEtcStatBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(stat: CharacterUiState.CharacterEtcStat) {
+            binding.stat = stat
+        }
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/character/CharacterUiState.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/character/CharacterUiState.kt
@@ -1,0 +1,27 @@
+package com.bodan.maplecalendar.presentation.character
+
+import java.util.UUID
+
+sealed class CharacterUiState(val id: String = UUID.randomUUID().toString()) {
+
+    data class CharacterDefaultStat(
+        val statTitle: String,
+        val statValue: String
+    ) : CharacterUiState()
+
+    data class CharacterMainStat(
+        val statTitle: String,
+        val statValue: String
+    ) : CharacterUiState()
+
+    data class CharacterEtcStat(
+        val statTitle: String,
+        val statValue: String
+    ) : CharacterUiState()
+
+    companion object {
+        const val DEFAULT_STAT_VIEW_TYPE = 1
+        const val MAIN_STAT_VIEW_TYPE = 2
+        const val ETC_STAT_VIEW_TYPE = 3
+    }
+}

--- a/app/src/main/res/layout/fragment_character.xml
+++ b/app/src/main/res/layout/fragment_character.xml
@@ -10,114 +10,195 @@
             name="vm"
             type="com.bodan.maplecalendar.presentation.CharacterViewModel" />
 
+        <variable
+            name="defaultStatListAdapter"
+            type="com.bodan.maplecalendar.presentation.character.CharacterDefaultStatListAdapter" />
+
+        <variable
+            name="mainStatListAdapter"
+            type="com.bodan.maplecalendar.presentation.character.CharacterMainStatListAdapter" />
+
+        <variable
+            name="etcStatListAdapter"
+            type="com.bodan.maplecalendar.presentation.character.CharacterEtcStatListAdapter" />
+
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context=".presentation.character.CharacterFragment">
+        android:layout_height="match_parent">
 
-        <TextView
-            android:id="@+id/tv_character_name_character"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/title_start"
-            android:layout_marginTop="@dimen/title_top"
-            android:fontFamily="@font/pretendardregular"
-            android:text="@{vm.characterName}"
-            android:textSize="@dimen/title_font_size_large"
-            app:layout_constraintBottom_toTopOf="@id/iv_character_character"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            tools:context=".presentation.character.CharacterFragment">
 
-        <androidx.appcompat.widget.AppCompatImageView
-            android:id="@+id/iv_character_character"
-            android:layout_width="@dimen/image_width"
-            android:layout_height="@dimen/image_height"
-            android:layout_marginStart="@dimen/image_start"
-            android:layout_marginTop="@dimen/image_top"
-            android:layout_marginBottom="@dimen/image_bottom"
-            android:background="@drawable/shape_dialog"
-            android:contentDescription="@string/description_character_profile"
-            android:elevation="10dp"
-            app:layout_constraintBottom_toTopOf="@id/tv_stat_character"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_character_name_character"
-            app:profileImage="@{vm.characterBasic.characterImage}" />
+            <TextView
+                android:id="@+id/tv_character_level_character"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/title_top"
+                android:paddingStart="24dp"
+                android:paddingEnd="24dp"
+                android:text="@{vm.characterLevel}"
+                android:textSize="@dimen/title_font_size_small"
+                app:layout_constraintBottom_toTopOf="@id/iv_character_character"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/tv_level_character"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/title_start"
-            android:text="@string/text_lv"
-            android:textSize="@dimen/title_font_size_small"
-            app:layout_constraintEnd_toStartOf="@id/tv_character_level_character"
-            app:layout_constraintStart_toEndOf="@id/iv_character_character"
-            app:layout_constraintTop_toTopOf="@id/iv_character_character" />
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/iv_character_character"
+                android:layout_width="@dimen/image_width"
+                android:layout_height="@dimen/image_height"
+                android:layout_marginTop="@dimen/image_top"
+                android:layout_marginBottom="24dp"
+                android:background="@drawable/shape_dialog"
+                android:contentDescription="@string/description_character_profile"
+                android:elevation="10dp"
+                app:layout_constraintBottom_toTopOf="@id/tv_character_name_character"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_character_level_character"
+                app:profileImage="@{vm.characterBasic.characterImage}" />
 
-        <TextView
-            android:id="@+id/tv_character_level_character"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@{vm.characterLevel}"
-            android:textSize="@dimen/title_font_size_small"
-            app:layout_constraintBottom_toBottomOf="@id/tv_level_character"
-            app:layout_constraintStart_toEndOf="@id/tv_level_character"
-            app:layout_constraintTop_toTopOf="@id/tv_level_character" />
+            <TextView
+                android:id="@+id/tv_character_class_character"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/title_start"
+                android:layout_marginTop="@dimen/title_top"
+                android:layout_marginEnd="@dimen/title_end"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                android:text="@{vm.characterBasic.characterClass}"
+                android:textSize="@dimen/title_font_size_small"
+                app:layout_constraintEnd_toStartOf="@id/iv_character_character"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@id/iv_character_character" />
 
-        <TextView
-            android:id="@+id/tv_character_class_character"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@{vm.characterBasic.characterClass}"
-            android:textSize="@dimen/title_font_size_small"
-            app:layout_constraintBottom_toTopOf="@id/tv_guild_character"
-            app:layout_constraintStart_toStartOf="@id/tv_level_character"
-            app:layout_constraintTop_toBottomOf="@id/tv_level_character" />
+            <TextView
+                android:id="@+id/tv_guild_character"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/title_start"
+                android:text="@string/text_guild"
+                android:textSize="@dimen/title_font_size_small"
+                app:layout_constraintBottom_toBottomOf="@id/tv_character_guild_character"
+                app:layout_constraintStart_toEndOf="@id/iv_character_character"
+                app:layout_constraintTop_toTopOf="@id/tv_character_guild_character" />
 
-        <TextView
-            android:id="@+id/tv_guild_character"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@{vm.characterBasic.characterGuildName}"
-            android:textSize="@dimen/title_font_size_small"
-            app:layout_constraintStart_toStartOf="@id/tv_level_character"
-            app:layout_constraintTop_toBottomOf="@id/tv_character_class_character" />
+            <TextView
+                android:id="@+id/tv_character_guild_character"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/title_end"
+                android:text="@{vm.characterBasic.characterGuildName}"
+                android:textSize="@dimen/title_font_size_small"
+                app:layout_constraintBottom_toBottomOf="@id/iv_character_character"
+                app:layout_constraintEnd_toEndOf="parent" />
 
-        <TextView
-            android:id="@+id/tv_stat_character"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/title_start"
-            android:layout_marginTop="@dimen/title_top"
-            android:text="@string/text_character_stat"
-            android:textSize="@dimen/title_font_size_large"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/iv_character_character" />
+            <TextView
+                android:id="@+id/tv_character_name_character"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/title_top"
+                android:fontFamily="@font/pretendardregular"
+                android:paddingStart="24dp"
+                android:paddingEnd="24dp"
+                android:text="@{vm.characterName}"
+                android:textSize="@dimen/title_font_size_large"
+                app:layout_constraintBottom_toTopOf="@id/tv_stat_character"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/iv_character_character" />
 
-        <TextView
-            android:id="@+id/tv_power_character"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/title_start"
-            android:text="@string/text_character_power"
-            android:textSize="@dimen/title_font_size_big"
-            app:layout_constraintEnd_toStartOf="@id/tv_character_power_character"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_stat_character" />
+            <TextView
+                android:id="@+id/tv_stat_character"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/title_top"
+                android:text="@string/text_character_stat"
+                android:textSize="@dimen/title_font_size_large"
+                app:layout_constraintBottom_toTopOf="@id/tv_power_character"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_character_name_character" />
 
-        <TextView
-            android:id="@+id/tv_character_power_character"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/title_start"
-            android:text="@{vm.characterStatInfo.characterPower}"
-            android:textSize="@dimen/title_font_size_big"
-            app:layout_constraintBottom_toBottomOf="@id/tv_power_character"
-            app:layout_constraintStart_toEndOf="@id/tv_power_character"
-            app:layout_constraintTop_toTopOf="@id/tv_power_character" />
+            <TextView
+                android:id="@+id/tv_power_character"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/title_start"
+                android:layout_marginTop="@dimen/title_top"
+                android:text="@string/text_character_power"
+                android:textSize="@dimen/title_font_size_big"
+                app:layout_constraintBottom_toTopOf="@id/rv_default_stat_character"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_stat_character" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <TextView
+                android:id="@+id/tv_character_power_character"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@{vm.characterPower}"
+                android:textSize="@dimen/title_font_size_big"
+                app:layout_constraintBottom_toBottomOf="@id/tv_power_character"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@id/tv_power_character" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_default_stat_character"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/title_top"
+                android:adapter="@{defaultStatListAdapter}"
+                android:elevation="10dp"
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                app:layout_constraintBottom_toTopOf="@id/rv_main_stat_character"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_power_character"
+                app:spanCount="2"
+                app:submitData="@{vm.characterDefaultStatData}"
+                tools:listitem="@layout/item_character_default_stat" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_main_stat_character"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/title_top"
+                android:adapter="@{mainStatListAdapter}"
+                android:elevation="10dp"
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                app:layout_constraintBottom_toTopOf="@id/rv_etc_stat_character"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/rv_default_stat_character"
+                app:spanCount="2"
+                app:submitData="@{vm.characterMainStatData}"
+                tools:listitem="@layout/item_character_main_stat" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_etc_stat_character"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/title_top"
+                android:layout_marginBottom="@dimen/title_bottom"
+                android:adapter="@{etcStatListAdapter}"
+                android:elevation="10dp"
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/rv_main_stat_character"
+                app:spanCount="2"
+                app:submitData="@{vm.characterEtcStatData}"
+                tools:listitem="@layout/item_character_etc_stat" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.core.widget.NestedScrollView>
 
 </layout>

--- a/app/src/main/res/layout/item_character_default_stat.xml
+++ b/app/src/main/res/layout/item_character_default_stat.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="stat"
+            type="com.bodan.maplecalendar.presentation.character.CharacterUiState.CharacterDefaultStat" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/item_character_default_stat"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/title_start"
+        android:paddingEnd="@dimen/title_end">
+
+        <TextView
+            android:id="@+id/tv_title_default_stat"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{stat.statTitle}"
+            android:textSize="@dimen/title_font_size_small"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_value_default_stat"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{stat.statValue}"
+            android:textSize="@dimen/title_font_size_small"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/item_character_etc_stat.xml
+++ b/app/src/main/res/layout/item_character_etc_stat.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="stat"
+            type="com.bodan.maplecalendar.presentation.character.CharacterUiState.CharacterEtcStat" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/item_character_etc_stat"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/title_start"
+        android:paddingEnd="@dimen/title_end">
+
+        <TextView
+            android:id="@+id/tv_title_etc_stat"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{stat.statTitle}"
+            android:textSize="@dimen/title_font_size_small"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_value_etc_stat"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{stat.statValue}"
+            android:textSize="@dimen/title_font_size_small"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/item_character_main_stat.xml
+++ b/app/src/main/res/layout/item_character_main_stat.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="stat"
+            type="com.bodan.maplecalendar.presentation.character.CharacterUiState.CharacterMainStat" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/item_character_main_stat"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/title_start"
+        android:paddingEnd="@dimen/title_end">
+
+        <TextView
+            android:id="@+id/tv_title_main_stat"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{stat.statTitle}"
+            android:textSize="@dimen/title_font_size_small"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_value_main_stat"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{stat.statValue}"
+            android:textSize="@dimen/title_font_size_small"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>


### PR DESCRIPTION
## 2024. 02. 21
  - 캐릭터의 종합 능력치는 다음과 같이 구분한다.
    - 기본 능력치 : 힘, 덱, 인, 럭, 체력, 마나
    - 핵심 능력치 : 스공, 뎀퍼, 보공, 방무, 최종뎀 등 사냥 및 보스에서 핵심적으로 적용되는 능력치
    - 기타 능력치 : 드랍, 메획, 이동속도, 점프력 등 기타 능력치
  - 3가지의 능력치는 3개의 RecyclerView로 구분하여 출력한다.
    - 일단은 3개의 ListAdapter를 사용했는데, 하나의 Adapter로 모든 RecyclerView에 대응할 수 있는 GeneralAdapter라는 것이 존재한다고 하여 나중에 적용시켜보고자 한다.
  - 또한 능력치의 수치별 단위(%, 자릿수 구분 콤마, 자릿수 구분 단위(억, 만 등..), 공격 속도 N단계)를 출력하는 함수를 선언하였다.
  - 실행 결과
    <p>
       <img width=250 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/09c1b81e-f7b2-421a-86fd-37b331d0a305">
    </p>