### PR TITLE
[2/29] 뒤로 가기 개선, 캐릭터 정보 관련 안내 추가

### DIFF
--- a/app/src/main/java/com/bodan/maplecalendar/presentation/BaseFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/BaseFragment.kt
@@ -1,10 +1,12 @@
 package com.bodan.maplecalendar.presentation
 
+import android.content.Context
 import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
@@ -24,6 +26,13 @@ abstract class BaseFragment<T : ViewDataBinding>(private val layoutId: Int) : Fr
     private var _binding: T? = null
     protected val binding
         get() = requireNotNull(_binding)
+    private lateinit var onBackPressedCallback: OnBackPressedCallback
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+
+        setBackPressedCallback()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -73,5 +82,15 @@ abstract class BaseFragment<T : ViewDataBinding>(private val layoutId: Int) : Fr
 
     protected fun showSnackBar(messageId: Int) {
         Snackbar.make(this.requireView(), messageId, Snackbar.LENGTH_LONG).show()
+    }
+
+    private fun setBackPressedCallback() {
+        onBackPressedCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                requireActivity().finish()
+            }
+        }
+
+        requireActivity().onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
     }
 }

--- a/app/src/main/res/drawable/shape_information.xml
+++ b/app/src/main/res/drawable/shape_information.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/listview_background_shape">
+    <stroke
+        android:width="2dp"
+        android:color="@color/main" />
+    <corners android:radius="10dp" />
+    <solid android:color="@color/white" />
+</shape>

--- a/app/src/main/res/drawable/shape_information_icon.xml
+++ b/app/src/main/res/drawable/shape_information_icon.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/listview_background_shape"
+    android:shape="oval">
+    <solid android:color="@color/main" />
+</shape>

--- a/app/src/main/res/layout/fragment_lobby.xml
+++ b/app/src/main/res/layout/fragment_lobby.xml
@@ -86,7 +86,7 @@
                     android:text="@{vm.characterName}"
                     android:textColor="@color/main"
                     android:textSize="@dimen/title_font_size_small"
-                    app:layout_constraintBottom_toTopOf="@id/iv_character_lobby"
+                    app:layout_constraintBottom_toTopOf="@id/mcv_information_lobby"
                     app:layout_constraintEnd_toStartOf="@id/tv_character_info_lobby"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/rv_lobby" />
@@ -122,22 +122,76 @@
                     android:text="@{vm.searchDate}"
                     android:textSize="@dimen/title_font_size_mini"
                     app:layout_constraintBottom_toBottomOf="@id/tv_character_name_lobby"
-                    app:layout_constraintEnd_toStartOf="@id/btn_character_detail"
-                    app:layout_constraintTop_toTopOf="@id/tv_character_name_lobby" />
-
-                <androidx.appcompat.widget.AppCompatButton
-                    android:id="@+id/btn_character_detail"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_marginEnd="@dimen/title_end"
-                    android:background="@android:color/transparent"
-                    android:fontFamily="@font/pretendardregular"
-                    android:onClick="@{() -> vm.goToCharacter()}"
-                    android:text="@string/text_character_detail"
-                    android:textSize="@dimen/title_font_size_mini"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_character_name_lobby"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="@id/tv_character_name_lobby" />
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/mcv_information_lobby"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    app:layout_constraintBottom_toTopOf="@id/iv_character_lobby"
+                    app:layout_constraintEnd_toEndOf="@id/tv_character_search_date"
+                    app:layout_constraintStart_toStartOf="@id/tv_character_name_lobby"
+                    app:layout_constraintTop_toBottomOf="@id/tv_character_name_lobby">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:background="@drawable/shape_information"
+                        android:padding="12dp">
+
+                        <androidx.appcompat.widget.AppCompatImageView
+                            android:id="@+id/iv_information_lobby"
+                            android:layout_width="50dp"
+                            android:layout_height="0dp"
+                            android:background="@drawable/shape_information_icon"
+                            android:padding="10dp"
+                            android:scaleType="fitCenter"
+                            android:src="@drawable/maple_calendar_logo"
+                            app:layout_constraintBottom_toBottomOf="@id/tv_information_profile_lobby"
+                            app:layout_constraintDimensionRatio="1:1"
+                            app:layout_constraintEnd_toStartOf="@id/tv_information_date_lobby"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="@id/tv_information_date_lobby" />
+
+                        <TextView
+                            android:id="@+id/tv_information_date_lobby"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="12dp"
+                            android:fontFamily="@font/pretendardregular"
+                            android:text="@string/text_information_date"
+                            app:layout_constraintBottom_toTopOf="@id/tv_information_time_lobby"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toEndOf="@id/iv_information_lobby"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <TextView
+                            android:id="@+id/tv_information_time_lobby"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/pretendardregular"
+                            android:text="@string/text_information_time"
+                            app:layout_constraintBottom_toTopOf="@id/tv_information_profile_lobby"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toStartOf="@id/tv_information_date_lobby"
+                            app:layout_constraintTop_toBottomOf="@id/tv_information_date_lobby" />
+
+                        <TextView
+                            android:id="@+id/tv_information_profile_lobby"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/pretendardregular"
+                            android:text="@string/text_information_profile"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toStartOf="@id/tv_information_date_lobby"
+                            app:layout_constraintTop_toBottomOf="@id/tv_information_time_lobby" />
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                </com.google.android.material.card.MaterialCardView>
 
                 <androidx.appcompat.widget.AppCompatImageView
                     android:id="@+id/iv_character_lobby"
@@ -149,9 +203,10 @@
                     android:background="@drawable/shape_dialog"
                     android:contentDescription="@string/description_character_profile"
                     android:elevation="10dp"
+                    android:onClick="@{() -> vm.goToCharacter()}"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_character_name_lobby"
+                    app:layout_constraintTop_toBottomOf="@id/mcv_information_lobby"
                     app:profileImage="@{vm.characterImage}" />
 
                 <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,9 @@
     <string name="text_character_info">에 대한 정보</string>
     <string name="text_search_date">기준일 : &#160;</string>
     <string name="text_character_detail">자세히 보기</string>
+    <string name="text_information_date">캐릭터의 상세 정보는 2023년 12월 21일 이후에 접속한 캐릭터만 가능해요.</string>
+    <string name="text_information_time">캐릭터의 정보는 매일 01시마다 갱신돼요.</string>
+    <string name="text_information_profile">캐릭터 이미지를 클릭하면 캐릭터의 상세한 정보를 확인할 수 있어요.</string>
     <string name="text_event_example">이벤트</string>
     <string name="text_level">레벨</string>
     <string name="text_lv">Lv.</string>


### PR DESCRIPTION
## 2024. 02. 29
 - StartDestination이 아닌 Fragment에서 백버튼 터치 시 Activity 및 앱 종료
 - 로비의 캐릭터 정보 UI 위에 2023년 12월 21일 이후 접속한 계정의 캐릭터만 상세 정보 확인이 가능하다는 문구 추가
 - 자세히 보기 버튼 문구를 상세 정보 확인으로 바꾸고 좀 더 잘 보이고 터치도 잘 되는 정도로 큰 버튼으로 변경
   - 캐릭터 프로필 이미지를 클릭할 시 상세 화면으로 넘어가도록 변경
 - 실행 결과
    <p>
       <img width=50 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/eefc34a6-84e9-4163-937e-19b412c81a23">
       <img width=150 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/478f9834-05d1-48bc-9e21-f9d46b0211a5">
    </p>