### PR TITLE
[4/22] 캐릭터 실시간 정보 조회(기능 추가 시작)

### DIFF
--- a/app/src/main/java/com/bodan/maplecalendar/data/network/MaplestoryApi.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/network/MaplestoryApi.kt
@@ -21,36 +21,36 @@ interface MaplestoryApi {
     @GET("v1/character/basic")
     suspend fun fetchCharacterBasic(
         @Query("ocid") ocid: String,
-        @Query("date") date: String
+        @Query("date") date: String?
     ): Response<CharacterBasic>
 
     @GET("v1/character/stat")
     suspend fun fetchCharacterStat(
         @Query("ocid") ocid: String,
-        @Query("date") date: String
+        @Query("date") date: String?
     ): Response<CharacterStat>
 
     @GET("v1/character/item-equipment")
     suspend fun fetchCharacterItemEquipment(
         @Query("ocid") ocid: String,
-        @Query("date") date: String
+        @Query("date") date: String?
     ): Response<CharacterItemEquipment>
 
     @GET("v1/user/union")
     suspend fun fetchCharacterUnion(
         @Query("ocid") ocid: String,
-        @Query("date") date: String
+        @Query("date") date: String?
     ): Response<CharacterUnion>
 
     @GET("v1/character/popularity")
     suspend fun fetchCharacterPopularity(
         @Query("ocid") ocid: String,
-        @Query("date") date: String
+        @Query("date") date: String?
     ): Response<CharacterPopularity>
 
     @GET("v1/character/dojang")
     suspend fun fetchCharacterDojang(
         @Query("ocid") ocid: String,
-        @Query("date") date: String
+        @Query("date") date: String?
     ): Response<CharacterDojang>
 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRepository.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRepository.kt
@@ -12,15 +12,15 @@ interface MaplestoryRepository {
 
     suspend fun getCharacterOcid(characterName: String): CharacterOcidResponse
 
-    suspend fun getCharacterBasic(ocid: String, date: String): CharacterBasicResponse
+    suspend fun getCharacterBasic(ocid: String, date: String?): CharacterBasicResponse
 
-    suspend fun getCharacterPower(ocid: String, date: String): CharacterStatResponse
+    suspend fun getCharacterPower(ocid: String, date: String?): CharacterStatResponse
 
-    suspend fun getCharacterItemEquipment(ocid: String, date: String): CharacterItemEquipmentResponse
+    suspend fun getCharacterItemEquipment(ocid: String, date: String?): CharacterItemEquipmentResponse
 
-    suspend fun getCharacterUnion(ocid: String, date: String): CharacterUnionResponse
+    suspend fun getCharacterUnion(ocid: String, date: String?): CharacterUnionResponse
 
-    suspend fun getCharacterPopularity(ocid: String, date: String): CharacterPopularityResponse
+    suspend fun getCharacterPopularity(ocid: String, date: String?): CharacterPopularityResponse
 
-    suspend fun getCharacterDojang(ocid: String, date: String): CharacterDojangResponse
+    suspend fun getCharacterDojang(ocid: String, date: String?): CharacterDojangResponse
 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRepositoryImpl.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRepositoryImpl.kt
@@ -80,7 +80,7 @@ class MaplestoryRepositoryImpl : MaplestoryRepository {
         )
     }
 
-    override suspend fun getCharacterBasic(ocid: String, date: String): CharacterBasicResponse {
+    override suspend fun getCharacterBasic(ocid: String, date: String?): CharacterBasicResponse {
         val response = maplestoryApi.fetchCharacterBasic(ocid = ocid, date = date)
 
         when (response.code()) {
@@ -135,7 +135,7 @@ class MaplestoryRepositoryImpl : MaplestoryRepository {
         )
     }
 
-    override suspend fun getCharacterPower(ocid: String, date: String): CharacterStatResponse {
+    override suspend fun getCharacterPower(ocid: String, date: String?): CharacterStatResponse {
         val response = maplestoryApi.fetchCharacterStat(ocid = ocid, date = date)
 
         when (response.code()) {
@@ -190,7 +190,7 @@ class MaplestoryRepositoryImpl : MaplestoryRepository {
         )
     }
 
-    override suspend fun getCharacterItemEquipment(ocid: String, date: String): CharacterItemEquipmentResponse {
+    override suspend fun getCharacterItemEquipment(ocid: String, date: String?): CharacterItemEquipmentResponse {
         val response = maplestoryApi.fetchCharacterItemEquipment(ocid = ocid, date = date)
 
         when (response.code()) {
@@ -245,7 +245,7 @@ class MaplestoryRepositoryImpl : MaplestoryRepository {
         )
     }
 
-    override suspend fun getCharacterUnion(ocid: String, date: String): CharacterUnionResponse {
+    override suspend fun getCharacterUnion(ocid: String, date: String?): CharacterUnionResponse {
         val response = maplestoryApi.fetchCharacterUnion(ocid = ocid, date = date)
 
         when (response.code()) {
@@ -300,7 +300,7 @@ class MaplestoryRepositoryImpl : MaplestoryRepository {
         )
     }
 
-    override suspend fun getCharacterPopularity(ocid: String, date: String): CharacterPopularityResponse {
+    override suspend fun getCharacterPopularity(ocid: String, date: String?): CharacterPopularityResponse {
         val response = maplestoryApi.fetchCharacterPopularity(ocid = ocid, date = date)
 
         when (response.code()) {
@@ -355,7 +355,7 @@ class MaplestoryRepositoryImpl : MaplestoryRepository {
         )
     }
 
-    override suspend fun getCharacterDojang(ocid: String, date: String): CharacterDojangResponse {
+    override suspend fun getCharacterDojang(ocid: String, date: String?): CharacterDojangResponse {
         val response = maplestoryApi.fetchCharacterDojang(ocid = ocid, date = date)
 
         when (response.code()) {

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/MainViewModel.kt
@@ -50,8 +50,11 @@ class MainViewModel : ViewModel(), OnDateClickListener, OnEventClickListener {
 
     private val todayFormatted = MutableStateFlow<String>("")
 
-    private val _searchDate = MutableStateFlow<String>("")
+    private val _searchDate = MutableStateFlow<String?>(null)
     val searchDate = _searchDate.asStateFlow()
+
+    private val _isDateNow = MutableStateFlow<Boolean>(false)
+    val isDateNow = _isDateNow.asStateFlow()
 
     private val currentMinute = MutableStateFlow<Int>(-1)
 
@@ -341,6 +344,22 @@ class MainViewModel : ViewModel(), OnDateClickListener, OnEventClickListener {
     fun goToCharacter() {
         viewModelScope.launch {
             _lobbyUiEvent.emit(LobbyUiEvent.GoToCharacter)
+        }
+    }
+
+    fun setDateNow(isChecked: Boolean) {
+        viewModelScope.launch {
+            when (isChecked) {
+                true -> {
+                    _searchDate.value = null
+                }
+
+                false -> {
+                    setToday().await()
+                }
+            }
+            setCharacterName()
+            getCharacterOcid()
         }
     }
 

--- a/app/src/main/res/layout/fragment_lobby.xml
+++ b/app/src/main/res/layout/fragment_lobby.xml
@@ -102,6 +102,18 @@
                     app:layout_constraintStart_toEndOf="@id/tv_character_name_lobby"
                     app:layout_constraintTop_toTopOf="@id/tv_character_name_lobby" />
 
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/switch_lobby"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    android:layout_marginEnd="8dp"
+                    android:checked="@{vm.isDateNow}"
+                    android:onCheckedChanged="@{(_, isChecked) -> vm.setDateNow(isChecked)}"
+                    android:padding="8dp"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_character_search_date"
+                    app:layout_constraintEnd_toStartOf="@id/tv_search_date"
+                    app:layout_constraintTop_toTopOf="@id/tv_character_search_date" />
+
                 <TextView
                     android:id="@+id/tv_search_date"
                     android:layout_width="wrap_content"
@@ -119,7 +131,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="@dimen/title_end"
                     android:fontFamily="@font/pretendardregular"
-                    android:text="@{vm.searchDate}"
+                    android:text="@{(vm.searchDate == null) ? @string/text_search_date_now : vm.searchDate}"
                     android:textSize="@dimen/title_font_size_mini"
                     app:layout_constraintBottom_toBottomOf="@id/tv_character_name_lobby"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -139,6 +151,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:background="@drawable/shape_information"
+                        android:backgroundTint="@null"
                         android:padding="12dp">
 
                         <androidx.appcompat.widget.AppCompatImageView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,8 +24,9 @@
     <string name="text_specific_date_event">에 진행중인 이벤트는…</string>
     <string name="text_character_info">에 대한 정보</string>
     <string name="text_search_date">기준일 : &#160;</string>
+    <string name="text_search_date_now">실시간</string>
     <string name="text_character_detail">자세히 보기</string>
-    <string name="text_information_date">캐릭터의 상세 정보는 2023년 12월 21일 이후에 접속한 캐릭터만 가능해요.</string>
+    <string name="text_information_date">캐릭터의 상세 정보는 2023년 12월 21일 이후에 접속한 캐릭터만 확인 가능해요.</string>
     <string name="text_information_time">캐릭터의 정보는 매일 01시마다 갱신돼요.</string>
     <string name="text_information_profile">캐릭터 이미지를 클릭하면 캐릭터의 상세한 정보를 확인할 수 있어요.</string>
     <string name="text_event_example">이벤트</string>


### PR DESCRIPTION
## 2024. 04. 22
 - SwitchCompat으로 캐릭터의 특정 날짜 정보를 조회할 것인지, 아니면 실시간 정보를 조회할 것인지 선택 가능
 - 추후 특정 날짜를 선택할 수 있는 달력 UI를 구현할 예정임
 - 실행 결과
    <p>
       <img width=150 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/b98cec40-93ae-4e12-8811-26ac30248dd0">
    </p>