### PR TITLE
[4/24] Custom View와 ViewPager2를 활용한 달력 UI 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,6 +81,9 @@ dependencies {
 
     implementation("io.coil-kt:coil:2.0.0-rc03")
 
+    // ViewPager2
+    implementation("androidx.viewpager2:viewpager2:1.0.0")
+
     // Retrofit2
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-scalars:2.9.0")

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/DateFormatConverter.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/DateFormatConverter.kt
@@ -2,13 +2,13 @@ package com.bodan.maplecalendar.presentation
 
 import com.bodan.maplecalendar.R
 import com.bodan.maplecalendar.app.MainApplication
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Calendar
 
 class DateFormatConverter {
 
-    private val twoDaysAgo = LocalDateTime.now().plusDays(-2)
     private val yesterdayTime = LocalDateTime.now().plusDays(-1)
     private val todayTime = LocalDateTime.now()
     private val formatter = DateTimeFormatter.ISO_LOCAL_DATE
@@ -35,8 +35,9 @@ class DateFormatConverter {
         return todayTime.dayOfMonth
     }
 
-    fun twoDaysAgoFormatted(): String {
-        return twoDaysAgo.format(formatter)
+    fun selectedSearchDateFormatted(year: Int, month: Int, day: Int): String {
+        val selectedSearchDate = LocalDate.of(year, month, day)
+        return formatter.format(selectedSearchDate)
     }
 
     fun yesterdayFormatted(): String {

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/MainViewModel.kt
@@ -3,7 +3,6 @@ package com.bodan.maplecalendar.presentation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bodan.maplecalendar.app.MainApplication
-import com.bodan.maplecalendar.app.MySharedPreferences
 import com.bodan.maplecalendar.data.EventListReader
 import com.bodan.maplecalendar.data.ResponseStatus
 import com.bodan.maplecalendar.data.repository.MaplestoryRepository
@@ -65,8 +64,6 @@ class MainViewModel : ViewModel(), OnDateClickListener, OnEventClickListener {
 
     private val _isDateNow = MutableStateFlow<Boolean>(true)
     val isDateNow = _isDateNow.asStateFlow()
-
-    private val currentMinute = MutableStateFlow<Int>(-1)
 
     private val _eventItems = MutableStateFlow<List<EventItem>>(listOf())
     val eventItems = _eventItems.asStateFlow()
@@ -366,8 +363,17 @@ class MainViewModel : ViewModel(), OnDateClickListener, OnEventClickListener {
         }
     }
 
-    fun selectSearchDate() {
+    fun selectSearchDate(year: Int, month: Int, day: Int) {
         viewModelScope.launch {
+            val deferred = async {
+                val selectedSearchDate =
+                    dateFormatConverter.selectedSearchDateFormatted(year, month, day)
+                MainApplication.mySharedPreferences.setSearchDate("searchDate", selectedSearchDate)
+            }
+            deferred.await()
+            setSearchDate().await()
+            setCharacterName()
+            getCharacterOcid()
             _lobbyUiEvent.emit(LobbyUiEvent.CloseSearchDate)
         }
     }
@@ -386,6 +392,7 @@ class MainViewModel : ViewModel(), OnDateClickListener, OnEventClickListener {
                     )
                 }
             }
+            _isDateNow.value = isChecked
             setSearchDate().await()
             setCharacterName()
             getCharacterOcid()

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/lobby/CalendarItemView.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/lobby/CalendarItemView.kt
@@ -1,25 +1,31 @@
 package com.bodan.maplecalendar.presentation.lobby
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Rect
 import android.text.TextPaint
 import android.util.AttributeSet
 import android.view.ContextThemeWrapper
+import android.view.MotionEvent
 import android.view.View
 import androidx.core.content.withStyledAttributes
 import com.bodan.maplecalendar.R
+import com.bodan.maplecalendar.presentation.MainViewModel
 import com.bodan.maplecalendar.presentation.utils.CalendarUtils.getDateColor
-import com.bodan.maplecalendar.presentation.utils.CalendarUtils.isSameMonth
-import org.joda.time.DateTime
+import com.bodan.maplecalendar.presentation.utils.CalendarUtils.isSearchDateRange
+import timber.log.Timber
 
+@SuppressLint("ClickableViewAccessibility")
 class CalendarItemView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = R.attr.calendarItemViewStyle,
     defStyleRes: Int = R.style.Calendar_CalendarItemViewStyle,
-    private val date: DateTime = DateTime(),
-    private val firstDayOfMonth: DateTime = DateTime()
+    private val year: Int = 0,
+    private val month: Int = 0,
+    private val day: Int = 0,
+    private val viewModel: MainViewModel? = null
 ) : View(ContextThemeWrapper(context, defStyleRes), attrs, defStyleAttr) {
 
     private val textBounds = Rect()
@@ -29,17 +35,48 @@ class CalendarItemView @JvmOverloads constructor(
         context.withStyledAttributes(attrs, R.styleable.CalendarView, defStyleAttr, defStyleRes) {
             textPaint.apply {
                 isAntiAlias = true
-                textSize = getDimensionPixelSize(R.styleable.CalendarView_calendarItemTextSize, 0).toFloat()
-                color = getDateColor(date.dayOfWeek)
-                if (!isSameMonth(date, firstDayOfMonth)) alpha = 50
+                textSize = getDimensionPixelSize(
+                    R.styleable.CalendarView_calendarItemTextSize,
+                    0
+                ).toFloat()
+                color = getDateColor(year, month, day)
+                typeface = getFont(R.styleable.CalendarView_calendarItemFontFamily)
+                if (!isSearchDateRange(year, month, day)) {
+                    alpha = 50
+                    color = context.resources.getColor(R.color.gray, context.theme)
+                }
             }
         }
+    }
+
+    override fun onTouchEvent(event: MotionEvent?): Boolean {
+        event ?: return true
+
+        when (event.action) {
+            MotionEvent.ACTION_DOWN -> {
+                invalidate()
+            }
+
+            MotionEvent.ACTION_UP -> {
+                invalidate()
+                Timber.d("${year}년 ${month}월 ${day}일")
+                if (isSearchDateRange(year, month, day)) viewModel?.selectSearchDate(
+                    year,
+                    month,
+                    day
+                )
+            }
+        }
+
+        return true
     }
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
 
-        val nowDate = date.dayOfMonth().toString()
+        if (day == -1) return
+
+        val nowDate = day.toString()
         textPaint.getTextBounds(nowDate, 0, nowDate.length, textBounds)
         canvas.drawText(
             nowDate,

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/lobby/CalendarView.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/lobby/CalendarView.kt
@@ -6,9 +6,9 @@ import android.view.ViewGroup
 import androidx.core.content.withStyledAttributes
 import androidx.core.view.children
 import com.bodan.maplecalendar.R
+import com.bodan.maplecalendar.presentation.MainViewModel
+import com.bodan.maplecalendar.presentation.utils.CalendarUtils.DAYS_PER_WEEK
 import com.bodan.maplecalendar.presentation.utils.CalendarUtils.WEEKS_PER_MONTH
-import org.joda.time.DateTime
-import org.joda.time.DateTimeConstants.DAYS_PER_WEEK
 import kotlin.math.max
 
 class CalendarView @JvmOverloads constructor(
@@ -55,13 +55,15 @@ class CalendarView @JvmOverloads constructor(
         }
     }
 
-    fun initCalendarView(firstDayOfMonth: DateTime, dateTimes: List<DateTime>) {
-        dateTimes.forEach { dateTime ->
+    fun initCalendarView(year: Int, month: Int, daysOfMonth: List<Int>, viewModel: MainViewModel) {
+        for (index in daysOfMonth.indices) {
             addView(
                 CalendarItemView(
                     context = context,
-                    date = dateTime,
-                    firstDayOfMonth = firstDayOfMonth
+                    year = year,
+                    month = month,
+                    day = daysOfMonth[index],
+                    viewModel = viewModel
                 )
             )
         }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/lobby/CustomCalendarAdapter.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/lobby/CustomCalendarAdapter.kt
@@ -2,27 +2,59 @@ package com.bodan.maplecalendar.presentation.lobby
 
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
-import org.joda.time.DateTime
+import com.bodan.maplecalendar.app.MainApplication
+import com.bodan.maplecalendar.presentation.DateFormatConverter
+import kotlin.math.abs
 
 class CustomCalendarAdapter(fm: FragmentActivity) : FragmentStateAdapter(fm) {
 
-    private var startDay: Long = DateTime().withDayOfMonth(1).withTimeAtStartOfDay().millis
+    private val dateFormatConverter = DateFormatConverter()
 
     override fun getItemCount(): Int = Int.MAX_VALUE
 
     override fun createFragment(position: Int): CustomCalendarFragment {
-        val millis = getItemId(position)
+        val itemId = getItemId(position)
 
-        return CustomCalendarFragment.newInstance(millis)
+        return CustomCalendarFragment.newInstance(itemId)
     }
 
-    override fun getItemId(position: Int): Long =
-        DateTime(startDay).plusMonths(position - START_POSITION).millis
+    override fun getItemId(position: Int): Long {
+        val searchDate =
+            MainApplication.mySharedPreferences.getSearchDate("searchDate", null) ?: return 0
+        var currentYear = searchDate.substring(0, 4).toInt()
+        var currentMonth = searchDate.substring(5, 7).toInt()
+
+        val move = position - START_POSITION
+        val bias = if (move < 0) -1 else 1
+
+        val moveYear = abs(move) / 12 * bias
+        val moveMonth = abs(move) % 12 * bias
+
+        currentYear += moveYear
+        when {
+            (currentMonth + moveMonth) < 1 -> {
+                currentMonth = 12 + (currentMonth + moveMonth)
+                currentYear--
+            }
+
+            (currentMonth + moveMonth) > 12 -> {
+                currentMonth = (currentMonth + moveMonth) - 12
+                currentYear++
+            }
+
+            else -> {
+                currentMonth = (currentMonth + moveMonth)
+            }
+        }
+
+        return (currentYear * 100 + currentMonth).toLong()
+    }
 
     override fun containsItem(itemId: Long): Boolean {
-        val date = DateTime(itemId)
+        val nowMonth =
+            ((dateFormatConverter.todayYear() * 100) + dateFormatConverter.todayMonth() + 1).toLong()
 
-        return ((date.dayOfMonth == 1) && (date.millisOfDay == 0))
+        return ((itemId > 202311L) && (itemId < nowMonth))
     }
 
     companion object {

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/lobby/CustomCalendarFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/lobby/CustomCalendarFragment.kt
@@ -5,42 +5,50 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.bodan.maplecalendar.R
+import androidx.fragment.app.activityViewModels
 import com.bodan.maplecalendar.databinding.FragmentCustomCalendarBinding
-import com.bodan.maplecalendar.presentation.utils.CalendarUtils.getMonthList
-import org.joda.time.DateTime
+import com.bodan.maplecalendar.presentation.MainViewModel
+import com.bodan.maplecalendar.presentation.utils.CalendarUtils.getDaysOfMonth
 
 class CustomCalendarFragment : Fragment() {
 
+    private val viewModel: MainViewModel by activityViewModels()
     private lateinit var binding: FragmentCustomCalendarBinding
-    private var millis: Long = 0L
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        arguments?.let { argument ->
-            millis = argument.getLong("MILLIS")
-        }
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-
         binding = FragmentCustomCalendarBinding.inflate(inflater, container, false)
-
-        binding.millis.text = DateTime(millis).toString("yyyy-MM")
-        binding.calendarview.initCalendarView(DateTime(millis), getMonthList(DateTime(millis)))
 
         return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.vm = viewModel
+
+        arguments?.let { argument ->
+            val year = argument.getLong("year").toInt()
+            val month = argument.getLong("month").toInt()
+            val text = "${year}년 ${month}월"
+            binding.tvDateInfoCustomCalendar.text = text
+            binding.calendarViewCustomCalendar.initCalendarView(
+                year,
+                month,
+                getDaysOfMonth(year, month),
+                viewModel
+            )
+        }
+    }
+
     companion object {
 
-        fun newInstance(millis: Long) = CustomCalendarFragment().apply {
+        fun newInstance(itemId: Long) = CustomCalendarFragment().apply {
             arguments = Bundle().apply {
-                putLong("MILLIS", millis)
+                putLong("year", itemId / 100L)
+                putLong("month", itemId % 100L)
             }
         }
     }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/lobby/SearchDateFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/lobby/SearchDateFragment.kt
@@ -1,7 +1,11 @@
 package com.bodan.maplecalendar.presentation.lobby
 
+import android.content.Context
+import android.os.Build
 import android.os.Bundle
 import android.view.View
+import android.view.WindowManager
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import com.bodan.maplecalendar.R
@@ -16,6 +20,12 @@ class SearchDateFragment :
 
     private val viewModel: MainViewModel by activityViewModels()
     private lateinit var customCalendarAdapter: CustomCalendarAdapter
+
+    override fun onResume() {
+        super.onResume()
+
+        requireContext().dialogFragmentResize(this, 0.8F, 0.5F)
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -40,6 +50,31 @@ class SearchDateFragment :
         with(binding.vpSearchDate) {
             adapter = customCalendarAdapter
             setCurrentItem(CustomCalendarAdapter.START_POSITION, false)
+        }
+    }
+
+    private fun Context.dialogFragmentResize(
+        dialogFragment: DialogFragment,
+        width: Float,
+        height: Float
+    ) {
+        val windowManager = getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        val window = dialogFragment.dialog?.window
+        if (Build.VERSION.SDK_INT < 30) {
+            val displayWidth = resources.displayMetrics.widthPixels
+            val displayHeight = resources.displayMetrics.heightPixels
+
+            val x = (displayWidth * width).toInt()
+            val y = (displayHeight * height).toInt()
+
+            window?.setLayout(x, y)
+        } else {
+            val rect = windowManager.currentWindowMetrics.bounds
+
+            val x = (rect.width() * width).toInt()
+            val y = (rect.height() * height).toInt()
+
+            window?.setLayout(x, y)
         }
     }
 }

--- a/app/src/main/res/layout/fragment_custom_calendar.xml
+++ b/app/src/main/res/layout/fragment_custom_calendar.xml
@@ -1,23 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <FrameLayout
+    <data>
+
+        <variable
+            name="vm"
+            type="com.bodan.maplecalendar.presentation.MainViewModel" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/white"
         tools:context=".presentation.lobby.CustomCalendarFragment">
 
-        <com.bodan.maplecalendar.presentation.lobby.CalendarView
-            android:id="@+id/calendarview"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
         <TextView
-            android:id="@+id/millis"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center" />
+            android:id="@+id/tv_date_info_custom_calendar"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/pretendardregular"
+            android:paddingTop="20dp"
+            android:paddingBottom="20dp"
+            android:textAlignment="center"
+            android:textColor="@color/black"
+            android:textSize="12sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    </FrameLayout>
+        <com.bodan.maplecalendar.presentation.lobby.CalendarView
+            android:id="@+id/calendar_view_custom_calendar"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_date_info_custom_calendar" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>

--- a/app/src/main/res/layout/fragment_lobby.xml
+++ b/app/src/main/res/layout/fragment_lobby.xml
@@ -5,6 +5,8 @@
 
     <data>
 
+        <import type="android.view.View" />
+
         <variable
             name="listAdapter"
             type="com.bodan.maplecalendar.presentation.lobby.EventListAdapter" />
@@ -78,6 +80,7 @@
                     android:clickable="true"
                     android:onClick="@{() -> vm.goToSelectSearchDate()}"
                     android:src="@drawable/ic_select_search_date"
+                    android:visibility="@{vm.isDateNow ? View.GONE : View.VISIBLE}"
                     app:layout_constraintBottom_toBottomOf="@id/tv_character_search_date"
                     app:layout_constraintEnd_toStartOf="@id/tv_search_date"
                     app:layout_constraintTop_toTopOf="@id/tv_character_search_date" />

--- a/app/src/main/res/layout/fragment_search_date.xml
+++ b/app/src/main/res/layout/fragment_search_date.xml
@@ -11,20 +11,29 @@
 
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context=".presentation.lobby.SearchDateFragment">
+        android:layout_height="match_parent">
 
-        <androidx.viewpager2.widget.ViewPager2
-            android:id="@+id/vp_search_date"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@drawable/shape_dialog"
+            android:elevation="2dp"
+            tools:context=".presentation.lobby.SearchDateFragment">
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <androidx.viewpager2.widget.ViewPager2
+                android:id="@+id/vp_search_date"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:padding="12dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
 
 </layout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -3,13 +3,17 @@
 
     <declare-styleable name="CalendarView">
 
+        <attr name="android:fontFamily" />
+
         <attr name="calendarViewStyle" format="reference" />
 
         <attr name="calendarItemViewStyle" format="reference" />
 
-        <attr name="calendarItemHeight" format="dimension"/>
+        <attr name="calendarItemHeight" format="dimension" />
 
-        <attr name="calendarItemTextSize" format="dimension"/>
+        <attr name="calendarItemTextSize" format="dimension" />
+
+        <attr name="calendarItemFontFamily" format="reference|integer" />
 
     </declare-styleable>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -36,6 +36,8 @@
 
         <item name="calendarItemTextSize">14sp</item>
 
+        <item name="calendarItemFontFamily">@font/pretendardregular</item>
+
     </style>
 
 </resources>


### PR DESCRIPTION
## 2024. 04. 24
 - Joda-Time은 오류가 발생하기 때문에 ViewModel에서 관리하는 최근 조회 날짜가 해당하는 연월을 기준으로 달력을 띄워주도록 한다.
 - 조회 날짜 선택용 달력 UI를 띄우는 데 성공했다면 날짜별로 터치가 가능하도록 하고 onTouchEvent를 재정의함으로써 터치 시 발생하는 이벤트를 추가하며, ViewModel에 터치한 날짜로 조회 날짜를 갱신하는 메소드를 정의한다.
 - 이후에는 2023년 12월 23일 이전의 날짜는 회색으로 표시하고 터치도 안 되게 해준다. 또한 금일 날짜부터도 터치가 안 되게 막고 다음 달로 넘어갈 수 없도록 막는다.
 - 실행 결과
    <p>
       <img width=250 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/deed846b-fcf5-4cbd-8093-291c684ec74f">
    </p>