### PR TITLE
[4/26] 조회 날짜 선택 Dialog의 높이 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@
  - AlarmManager의 setAlarmClock()과 PendingIntent를 정의해서 매일 00시에 BroadcastReceiver를 호출하고, BroadcastReceiver에서 NotificationManager를 정의하고 notify()로 알림을 보낼 수 있도록 하였음.
  - 하지만 setAlarmClock()은 반복이 불가능했고, 반복 알람을 구현하기 위해 onReceive()에서 다시 다음 날 00시에 알림을 예약하는 방식을 사용하였음.
 
+#### 2. Calendar with Custom View
+ - 좌우 스와이프가 되는 달력 View를 만들기 위하여 ViewPager2를 사용하였음.
+ - ViewPager2에 사용할 Fragment는 연월을 나타내는 TextView와, 달력 UI를 나타내는 Custom ViewGroup으로 구성되어 있음.
+ - ViewGroup은 요일이나 날짜를 나타내는 View들로 구성되어 있고, ViewGroup에서 요일 및 날짜를 나타내는 View의 layout을 구성함.
+ - 요일 View는 회색 배경으로 이루어져 있고, 날짜 View는 터치가 가능하고 터치 시 해당 날짜를 캐릭터 조회 날짜로 초기화함.
+   - View를 터치할 때 MotionEvent를 관찰하며, 터치 시작 시 해당 View의 배경색이 바뀌며 손가락을 떼거나 부모 View가 터치 이벤트를 가져가기 전까지 유지됨.
 
 ### References
 <a href="https://www.notion.so/MapleCalendar-93f45dc10b384d749e5ab00950324035?pvs=4">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.bodan.maplecalendar"
         minSdk = 28
         targetSdk = 34
-        versionCode = 14
-        versionName = "0.3.6"
+        versionCode = 16
+        versionName = "0.3.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/lobby/SearchDateFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/lobby/SearchDateFragment.kt
@@ -17,12 +17,6 @@ class SearchDateFragment :
     private val viewModel: MainViewModel by activityViewModels()
     private lateinit var customCalendarAdapter: CustomCalendarAdapter
 
-    override fun onResume() {
-        super.onResume()
-
-        requireContext().dialogFragmentResize(this, 0.8F, 0.5F)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/app/src/main/res/layout/fragment_custom_calendar.xml
+++ b/app/src/main/res/layout/fragment_custom_calendar.xml
@@ -13,8 +13,9 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:background="@color/white"
+        android:padding="20dp"
         tools:context=".presentation.lobby.CustomCalendarFragment">
 
         <TextView
@@ -33,13 +34,14 @@
 
         <com.bodan.maplecalendar.presentation.lobby.CalendarView
             android:id="@+id/calendar_view_custom_calendar"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="20dp"
             android:layout_marginEnd="20dp"
+            android:layout_marginBottom="20dp"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/tv_date_info_custom_calendar"
+            app:layout_constraintStart_toStartOf="@id/tv_date_info_custom_calendar"
             app:layout_constraintTop_toBottomOf="@id/tv_date_info_custom_calendar" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_search_date.xml
+++ b/app/src/main/res/layout/fragment_search_date.xml
@@ -16,16 +16,16 @@
         android:layout_height="match_parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:background="@drawable/shape_dialog"
             android:elevation="2dp"
             tools:context=".presentation.lobby.SearchDateFragment">
 
             <androidx.viewpager2.widget.ViewPager2
                 android:id="@+id/vp_search_date"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:padding="12dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## 2024. 04. 26
 - 날짜 선택 Dialog의 높이 변경
 - README.md 작성
 - 실행 결과
    <p>
       <img width=250 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/05d21bbe-4cce-468a-8432-f02473fc230f">
    </p>

Closes: #45, #46 