### PR TITLE
[5/9] 장비 프리셋 데이터 받아오기

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.bodan.maplecalendar"
         minSdk = 28
         targetSdk = 34
-        versionCode = 20
-        versionName = "0.4.4"
+        versionCode = 21
+        versionName = "0.4.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/bodan/maplecalendar/data/mapper/CharacterItemEquipmentMapper.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/mapper/CharacterItemEquipmentMapper.kt
@@ -2,13 +2,582 @@ package com.bodan.maplecalendar.data.mapper
 
 import com.bodan.maplecalendar.domain.entity.CharacterItemEquipment
 import com.bodan.maplecalendar.data.model.ItemEquipmentEntity
+import com.bodan.maplecalendar.domain.entity.ItemAddOption
+import com.bodan.maplecalendar.domain.entity.ItemBaseOption
+import com.bodan.maplecalendar.domain.entity.ItemEquipment
+import com.bodan.maplecalendar.domain.entity.ItemEtcOption
+import com.bodan.maplecalendar.domain.entity.ItemExceptionalOption
+import com.bodan.maplecalendar.domain.entity.ItemStarforceOption
+import com.bodan.maplecalendar.domain.entity.ItemTitle
+import com.bodan.maplecalendar.domain.entity.ItemTotalOption
 
 object CharacterItemEquipmentMapper {
 
     operator fun invoke(itemEquipmentEntity: ItemEquipmentEntity): CharacterItemEquipment {
+        val itemEquipments = mutableListOf<ItemEquipment>()
+        val itemEquipmentsFirstPreset = mutableListOf<ItemEquipment>()
+        val itemEquipmentsSecondPreset = mutableListOf<ItemEquipment>()
+        val itemEquipmentsThirdPreset = mutableListOf<ItemEquipment>()
+        val itemTitle = itemEquipmentEntity.itemTitle?.let { title ->
+            ItemTitle(
+                itemTitleName = title.itemTitleName,
+                itemTitleIcon = title.itemTitleIcon,
+                itemTitleDescription = title.itemTitleDescription,
+                itemTitleDateExpire = title.itemTitleDateExpire,
+                itemTitleDateOptionExpire = title.itemTitleDateOptionExpire
+            )
+        }
+
+        itemEquipmentEntity.itemEquipments.forEach { equipment ->
+            val totalOption = ItemTotalOption(
+                itemTotalStr = equipment.itemTotalOption.itemTotalStr,
+                itemTotalDex = equipment.itemTotalOption.itemTotalDex,
+                itemTotalInt = equipment.itemTotalOption.itemTotalInt,
+                itemTotalLuk = equipment.itemTotalOption.itemTotalLuk,
+                itemTotalMaxHp = equipment.itemTotalOption.itemTotalMaxHp,
+                itemTotalMaxMp = equipment.itemTotalOption.itemTotalMaxMp,
+                itemTotalAttackPower = equipment.itemTotalOption.itemTotalAttackPower,
+                itemTotalMagicPower = equipment.itemTotalOption.itemTotalMagicPower,
+                itemTotalArmor = equipment.itemTotalOption.itemTotalArmor,
+                itemTotalSpeed = equipment.itemTotalOption.itemTotalSpeed,
+                itemTotalJump = equipment.itemTotalOption.itemTotalJump,
+                itemTotalBossDamage = equipment.itemTotalOption.itemTotalBossDamage,
+                itemTotalIgnoreMonsterArmor = equipment.itemTotalOption.itemTotalIgnoreMonsterArmor,
+                itemTotalAllStat = equipment.itemTotalOption.itemTotalAllStat,
+                itemTotalDamage = equipment.itemTotalOption.itemTotalDamage,
+                itemTotalEquipmentLevelDecrease = equipment.itemTotalOption.itemTotalEquipmentLevelDecrease,
+                itemTotalMaxHpRate = equipment.itemTotalOption.itemTotalMaxHpRate,
+                itemTotalMaxMpRate = equipment.itemTotalOption.itemTotalMaxMpRate
+            )
+            val baseOption = ItemBaseOption(
+                itemBaseStr = equipment.itemBaseOption.itemBaseStr,
+                itemBaseDex = equipment.itemBaseOption.itemBaseDex,
+                itemBaseInt = equipment.itemBaseOption.itemBaseInt,
+                itemBaseLuk = equipment.itemBaseOption.itemBaseLuk,
+                itemBaseMaxHp = equipment.itemBaseOption.itemBaseMaxHp,
+                itemBaseMaxMp = equipment.itemBaseOption.itemBaseMaxMp,
+                itemBaseAttackPower = equipment.itemBaseOption.itemBaseAttackPower,
+                itemBaseMagicPower = equipment.itemBaseOption.itemBaseMagicPower,
+                itemBaseArmor = equipment.itemBaseOption.itemBaseArmor,
+                itemBaseSpeed = equipment.itemBaseOption.itemBaseSpeed,
+                itemBaseJump = equipment.itemBaseOption.itemBaseJump,
+                itemBaseBossDamage = equipment.itemBaseOption.itemBaseBossDamage,
+                itemBaseIgnoreMonsterArmor = equipment.itemBaseOption.itemBaseIgnoreMonsterArmor,
+                itemBaseAllStat = equipment.itemBaseOption.itemBaseAllStat,
+                itemBaseMaxHpRate = equipment.itemBaseOption.itemBaseMaxHpRate,
+                itemBaseMaxMpRate = equipment.itemBaseOption.itemBaseMaxMpRate,
+                itemBaseBaseEquipmentLevel = equipment.itemBaseOption.itemBaseBaseEquipmentLevel
+            )
+            val exceptionalOption = ItemExceptionalOption(
+                itemExceptionalStr = equipment.itemExceptionalOption.itemExceptionalStr,
+                itemExceptionalDex = equipment.itemExceptionalOption.itemExceptionalDex,
+                itemExceptionalInt = equipment.itemExceptionalOption.itemExceptionalInt,
+                itemExceptionalLuk = equipment.itemExceptionalOption.itemExceptionalLuk,
+                itemExceptionalMaxHp = equipment.itemExceptionalOption.itemExceptionalMaxHp,
+                itemExceptionalMaxMp = equipment.itemExceptionalOption.itemExceptionalMaxMp,
+                itemExceptionalAttackPower = equipment.itemExceptionalOption.itemExceptionalAttackPower,
+                itemExceptionalMagicPower = equipment.itemExceptionalOption.itemExceptionalMagicPower
+            )
+            val addOption = ItemAddOption(
+                itemAddStr = equipment.itemAddOption.itemAddStr,
+                itemAddDex = equipment.itemAddOption.itemAddDex,
+                itemAddInt = equipment.itemAddOption.itemAddInt,
+                itemAddLuk = equipment.itemAddOption.itemAddLuk,
+                itemAddMaxHp = equipment.itemAddOption.itemAddMaxHp,
+                itemAddMaxMp = equipment.itemAddOption.itemAddMaxMp,
+                itemAddAttackPower = equipment.itemAddOption.itemAddAttackPower,
+                itemAddMagicPower = equipment.itemAddOption.itemAddMagicPower,
+                itemAddArmor = equipment.itemAddOption.itemAddArmor,
+                itemAddSpeed = equipment.itemAddOption.itemAddSpeed,
+                itemAddJump = equipment.itemAddOption.itemAddJump,
+                itemAddBossDamage = equipment.itemAddOption.itemAddBossDamage,
+                itemAddDamage = equipment.itemAddOption.itemAddDamage,
+                itemAddAllStat = equipment.itemAddOption.itemAddAllStat,
+                itemAddEquipmentLevelDecrease = equipment.itemAddOption.itemAddEquipmentLevelDecrease
+            )
+            val etcOption = ItemEtcOption(
+                itemEtcStr = equipment.itemEtcOption.itemEtcStr,
+                itemEtcDex = equipment.itemEtcOption.itemEtcDex,
+                itemEtcInt = equipment.itemEtcOption.itemEtcInt,
+                itemEtcLuk = equipment.itemEtcOption.itemEtcLuk,
+                itemEtcMaxHp = equipment.itemEtcOption.itemEtcMaxHp,
+                itemEtcMaxMp = equipment.itemEtcOption.itemEtcMaxMp,
+                itemEtcAttackPower = equipment.itemEtcOption.itemEtcAttackPower,
+                itemEtcMagicPower = equipment.itemEtcOption.itemEtcMagicPower,
+                itemEtcArmor = equipment.itemEtcOption.itemEtcArmor,
+                itemEtcSpeed = equipment.itemEtcOption.itemEtcSpeed,
+                itemEtcJump = equipment.itemEtcOption.itemEtcJump
+            )
+            val starforceOption = ItemStarforceOption(
+                itemStarforceStr = equipment.itemStarforceOption.itemStarforceStr,
+                itemStarforceDex = equipment.itemStarforceOption.itemStarforceDex,
+                itemStarforceInt = equipment.itemStarforceOption.itemStarforceInt,
+                itemStarforceLuk = equipment.itemStarforceOption.itemStarforceLuk,
+                itemStarforceMaxHp = equipment.itemStarforceOption.itemStarforceMaxHp,
+                itemStarforceMaxMp = equipment.itemStarforceOption.itemStarforceMaxMp,
+                itemStarforceAttackPower = equipment.itemStarforceOption.itemStarforceAttackPower,
+                itemStarforceMagicPower = equipment.itemStarforceOption.itemStarforceMagicPower,
+                itemStarforceArmor = equipment.itemStarforceOption.itemStarforceArmor,
+                itemStarforceSpeed = equipment.itemStarforceOption.itemStarforceSpeed,
+                itemStarforceJump = equipment.itemStarforceOption.itemStarforceJump
+            )
+
+            itemEquipments.add(
+                ItemEquipment(
+                    itemEquipmentPart = equipment.itemEquipmentPart,
+                    equipmentSlot = equipment.equipmentSlot,
+                    itemName = equipment.itemName,
+                    itemIcon = equipment.itemIcon,
+                    itemDescription = equipment.itemDescription,
+                    itemShapeName = equipment.itemShapeName,
+                    itemShapeIcon = equipment.itemShapeIcon,
+                    itemGender = equipment.itemGender,
+                    itemTotalOption = totalOption,
+                    itemBaseOption = baseOption,
+                    potentialOptionGrade = equipment.potentialOptionGrade,
+                    additionalPotentialOptionGrade = equipment.additionalPotentialOptionGrade,
+                    potentialOptionFirst = equipment.potentialOptionFirst,
+                    potentialOptionSecond = equipment.potentialOptionSecond,
+                    potentialOptionThird = equipment.potentialOptionThird,
+                    additionalPotentialOptionFirst = equipment.additionalPotentialOptionFirst,
+                    additionalPotentialOptionSecond = equipment.additionalPotentialOptionSecond,
+                    additionalPotentialOptionThird = equipment.additionalPotentialOptionThird,
+                    equipmentLevelIncrease = equipment.equipmentLevelIncrease,
+                    itemExceptionalOption = exceptionalOption,
+                    itemAddOption = addOption,
+                    itemGrowthExp = equipment.itemGrowthExp,
+                    itemGrowthLevel = equipment.itemGrowthLevel,
+                    itemScrollUpgrade = equipment.itemScrollUpgrade,
+                    itemCuttableCount = equipment.itemCuttableCount,
+                    itemGoldenHammerFlag = equipment.itemGoldenHammerFlag,
+                    itemScrollResilienceCount = equipment.itemScrollResilienceCount,
+                    itemScrollUpgradableCount = equipment.itemScrollUpgradableCount,
+                    itemSoulName = equipment.itemSoulName,
+                    itemSoulOption = equipment.itemSoulOption,
+                    itemEtcOption = etcOption,
+                    itemStarforce = equipment.itemStarforce,
+                    itemStarforceScrollFlag = equipment.itemStarforceScrollFlag,
+                    itemStarforceOption = starforceOption,
+                    itemSpecialRingLevel = equipment.itemSpecialRingLevel,
+                    itemDateExpire = equipment.itemDateExpire
+                )
+            )
+        }
+
+        itemEquipmentEntity.itemEquipmentsFirstPreset.forEach { equipment ->
+            val totalOption = ItemTotalOption(
+                itemTotalStr = equipment.itemTotalOption.itemTotalStr,
+                itemTotalDex = equipment.itemTotalOption.itemTotalDex,
+                itemTotalInt = equipment.itemTotalOption.itemTotalInt,
+                itemTotalLuk = equipment.itemTotalOption.itemTotalLuk,
+                itemTotalMaxHp = equipment.itemTotalOption.itemTotalMaxHp,
+                itemTotalMaxMp = equipment.itemTotalOption.itemTotalMaxMp,
+                itemTotalAttackPower = equipment.itemTotalOption.itemTotalAttackPower,
+                itemTotalMagicPower = equipment.itemTotalOption.itemTotalMagicPower,
+                itemTotalArmor = equipment.itemTotalOption.itemTotalArmor,
+                itemTotalSpeed = equipment.itemTotalOption.itemTotalSpeed,
+                itemTotalJump = equipment.itemTotalOption.itemTotalJump,
+                itemTotalBossDamage = equipment.itemTotalOption.itemTotalBossDamage,
+                itemTotalIgnoreMonsterArmor = equipment.itemTotalOption.itemTotalIgnoreMonsterArmor,
+                itemTotalAllStat = equipment.itemTotalOption.itemTotalAllStat,
+                itemTotalDamage = equipment.itemTotalOption.itemTotalDamage,
+                itemTotalEquipmentLevelDecrease = equipment.itemTotalOption.itemTotalEquipmentLevelDecrease,
+                itemTotalMaxHpRate = equipment.itemTotalOption.itemTotalMaxHpRate,
+                itemTotalMaxMpRate = equipment.itemTotalOption.itemTotalMaxMpRate
+            )
+            val baseOption = ItemBaseOption(
+                itemBaseStr = equipment.itemBaseOption.itemBaseStr,
+                itemBaseDex = equipment.itemBaseOption.itemBaseDex,
+                itemBaseInt = equipment.itemBaseOption.itemBaseInt,
+                itemBaseLuk = equipment.itemBaseOption.itemBaseLuk,
+                itemBaseMaxHp = equipment.itemBaseOption.itemBaseMaxHp,
+                itemBaseMaxMp = equipment.itemBaseOption.itemBaseMaxMp,
+                itemBaseAttackPower = equipment.itemBaseOption.itemBaseAttackPower,
+                itemBaseMagicPower = equipment.itemBaseOption.itemBaseMagicPower,
+                itemBaseArmor = equipment.itemBaseOption.itemBaseArmor,
+                itemBaseSpeed = equipment.itemBaseOption.itemBaseSpeed,
+                itemBaseJump = equipment.itemBaseOption.itemBaseJump,
+                itemBaseBossDamage = equipment.itemBaseOption.itemBaseBossDamage,
+                itemBaseIgnoreMonsterArmor = equipment.itemBaseOption.itemBaseIgnoreMonsterArmor,
+                itemBaseAllStat = equipment.itemBaseOption.itemBaseAllStat,
+                itemBaseMaxHpRate = equipment.itemBaseOption.itemBaseMaxHpRate,
+                itemBaseMaxMpRate = equipment.itemBaseOption.itemBaseMaxMpRate,
+                itemBaseBaseEquipmentLevel = equipment.itemBaseOption.itemBaseBaseEquipmentLevel
+            )
+            val exceptionalOption = ItemExceptionalOption(
+                itemExceptionalStr = equipment.itemExceptionalOption.itemExceptionalStr,
+                itemExceptionalDex = equipment.itemExceptionalOption.itemExceptionalDex,
+                itemExceptionalInt = equipment.itemExceptionalOption.itemExceptionalInt,
+                itemExceptionalLuk = equipment.itemExceptionalOption.itemExceptionalLuk,
+                itemExceptionalMaxHp = equipment.itemExceptionalOption.itemExceptionalMaxHp,
+                itemExceptionalMaxMp = equipment.itemExceptionalOption.itemExceptionalMaxMp,
+                itemExceptionalAttackPower = equipment.itemExceptionalOption.itemExceptionalAttackPower,
+                itemExceptionalMagicPower = equipment.itemExceptionalOption.itemExceptionalMagicPower
+            )
+            val addOption = ItemAddOption(
+                itemAddStr = equipment.itemAddOption.itemAddStr,
+                itemAddDex = equipment.itemAddOption.itemAddDex,
+                itemAddInt = equipment.itemAddOption.itemAddInt,
+                itemAddLuk = equipment.itemAddOption.itemAddLuk,
+                itemAddMaxHp = equipment.itemAddOption.itemAddMaxHp,
+                itemAddMaxMp = equipment.itemAddOption.itemAddMaxMp,
+                itemAddAttackPower = equipment.itemAddOption.itemAddAttackPower,
+                itemAddMagicPower = equipment.itemAddOption.itemAddMagicPower,
+                itemAddArmor = equipment.itemAddOption.itemAddArmor,
+                itemAddSpeed = equipment.itemAddOption.itemAddSpeed,
+                itemAddJump = equipment.itemAddOption.itemAddJump,
+                itemAddBossDamage = equipment.itemAddOption.itemAddBossDamage,
+                itemAddDamage = equipment.itemAddOption.itemAddDamage,
+                itemAddAllStat = equipment.itemAddOption.itemAddAllStat,
+                itemAddEquipmentLevelDecrease = equipment.itemAddOption.itemAddEquipmentLevelDecrease
+            )
+            val etcOption = ItemEtcOption(
+                itemEtcStr = equipment.itemEtcOption.itemEtcStr,
+                itemEtcDex = equipment.itemEtcOption.itemEtcDex,
+                itemEtcInt = equipment.itemEtcOption.itemEtcInt,
+                itemEtcLuk = equipment.itemEtcOption.itemEtcLuk,
+                itemEtcMaxHp = equipment.itemEtcOption.itemEtcMaxHp,
+                itemEtcMaxMp = equipment.itemEtcOption.itemEtcMaxMp,
+                itemEtcAttackPower = equipment.itemEtcOption.itemEtcAttackPower,
+                itemEtcMagicPower = equipment.itemEtcOption.itemEtcMagicPower,
+                itemEtcArmor = equipment.itemEtcOption.itemEtcArmor,
+                itemEtcSpeed = equipment.itemEtcOption.itemEtcSpeed,
+                itemEtcJump = equipment.itemEtcOption.itemEtcJump
+            )
+            val starforceOption = ItemStarforceOption(
+                itemStarforceStr = equipment.itemStarforceOption.itemStarforceStr,
+                itemStarforceDex = equipment.itemStarforceOption.itemStarforceDex,
+                itemStarforceInt = equipment.itemStarforceOption.itemStarforceInt,
+                itemStarforceLuk = equipment.itemStarforceOption.itemStarforceLuk,
+                itemStarforceMaxHp = equipment.itemStarforceOption.itemStarforceMaxHp,
+                itemStarforceMaxMp = equipment.itemStarforceOption.itemStarforceMaxMp,
+                itemStarforceAttackPower = equipment.itemStarforceOption.itemStarforceAttackPower,
+                itemStarforceMagicPower = equipment.itemStarforceOption.itemStarforceMagicPower,
+                itemStarforceArmor = equipment.itemStarforceOption.itemStarforceArmor,
+                itemStarforceSpeed = equipment.itemStarforceOption.itemStarforceSpeed,
+                itemStarforceJump = equipment.itemStarforceOption.itemStarforceJump
+            )
+
+            itemEquipmentsFirstPreset.add(
+                ItemEquipment(
+                    itemEquipmentPart = equipment.itemEquipmentPart,
+                    equipmentSlot = equipment.equipmentSlot,
+                    itemName = equipment.itemName,
+                    itemIcon = equipment.itemIcon,
+                    itemDescription = equipment.itemDescription,
+                    itemShapeName = equipment.itemShapeName,
+                    itemShapeIcon = equipment.itemShapeIcon,
+                    itemGender = equipment.itemGender,
+                    itemTotalOption = totalOption,
+                    itemBaseOption = baseOption,
+                    potentialOptionGrade = equipment.potentialOptionGrade,
+                    additionalPotentialOptionGrade = equipment.additionalPotentialOptionGrade,
+                    potentialOptionFirst = equipment.potentialOptionFirst,
+                    potentialOptionSecond = equipment.potentialOptionSecond,
+                    potentialOptionThird = equipment.potentialOptionThird,
+                    additionalPotentialOptionFirst = equipment.additionalPotentialOptionFirst,
+                    additionalPotentialOptionSecond = equipment.additionalPotentialOptionSecond,
+                    additionalPotentialOptionThird = equipment.additionalPotentialOptionThird,
+                    equipmentLevelIncrease = equipment.equipmentLevelIncrease,
+                    itemExceptionalOption = exceptionalOption,
+                    itemAddOption = addOption,
+                    itemGrowthExp = equipment.itemGrowthExp,
+                    itemGrowthLevel = equipment.itemGrowthLevel,
+                    itemScrollUpgrade = equipment.itemScrollUpgrade,
+                    itemCuttableCount = equipment.itemCuttableCount,
+                    itemGoldenHammerFlag = equipment.itemGoldenHammerFlag,
+                    itemScrollResilienceCount = equipment.itemScrollResilienceCount,
+                    itemScrollUpgradableCount = equipment.itemScrollUpgradableCount,
+                    itemSoulName = equipment.itemSoulName,
+                    itemSoulOption = equipment.itemSoulOption,
+                    itemEtcOption = etcOption,
+                    itemStarforce = equipment.itemStarforce,
+                    itemStarforceScrollFlag = equipment.itemStarforceScrollFlag,
+                    itemStarforceOption = starforceOption,
+                    itemSpecialRingLevel = equipment.itemSpecialRingLevel,
+                    itemDateExpire = equipment.itemDateExpire
+                )
+            )
+        }
+
+        itemEquipmentEntity.itemEquipmentsSecondPreset.forEach { equipment ->
+            val totalOption = ItemTotalOption(
+                itemTotalStr = equipment.itemTotalOption.itemTotalStr,
+                itemTotalDex = equipment.itemTotalOption.itemTotalDex,
+                itemTotalInt = equipment.itemTotalOption.itemTotalInt,
+                itemTotalLuk = equipment.itemTotalOption.itemTotalLuk,
+                itemTotalMaxHp = equipment.itemTotalOption.itemTotalMaxHp,
+                itemTotalMaxMp = equipment.itemTotalOption.itemTotalMaxMp,
+                itemTotalAttackPower = equipment.itemTotalOption.itemTotalAttackPower,
+                itemTotalMagicPower = equipment.itemTotalOption.itemTotalMagicPower,
+                itemTotalArmor = equipment.itemTotalOption.itemTotalArmor,
+                itemTotalSpeed = equipment.itemTotalOption.itemTotalSpeed,
+                itemTotalJump = equipment.itemTotalOption.itemTotalJump,
+                itemTotalBossDamage = equipment.itemTotalOption.itemTotalBossDamage,
+                itemTotalIgnoreMonsterArmor = equipment.itemTotalOption.itemTotalIgnoreMonsterArmor,
+                itemTotalAllStat = equipment.itemTotalOption.itemTotalAllStat,
+                itemTotalDamage = equipment.itemTotalOption.itemTotalDamage,
+                itemTotalEquipmentLevelDecrease = equipment.itemTotalOption.itemTotalEquipmentLevelDecrease,
+                itemTotalMaxHpRate = equipment.itemTotalOption.itemTotalMaxHpRate,
+                itemTotalMaxMpRate = equipment.itemTotalOption.itemTotalMaxMpRate
+            )
+            val baseOption = ItemBaseOption(
+                itemBaseStr = equipment.itemBaseOption.itemBaseStr,
+                itemBaseDex = equipment.itemBaseOption.itemBaseDex,
+                itemBaseInt = equipment.itemBaseOption.itemBaseInt,
+                itemBaseLuk = equipment.itemBaseOption.itemBaseLuk,
+                itemBaseMaxHp = equipment.itemBaseOption.itemBaseMaxHp,
+                itemBaseMaxMp = equipment.itemBaseOption.itemBaseMaxMp,
+                itemBaseAttackPower = equipment.itemBaseOption.itemBaseAttackPower,
+                itemBaseMagicPower = equipment.itemBaseOption.itemBaseMagicPower,
+                itemBaseArmor = equipment.itemBaseOption.itemBaseArmor,
+                itemBaseSpeed = equipment.itemBaseOption.itemBaseSpeed,
+                itemBaseJump = equipment.itemBaseOption.itemBaseJump,
+                itemBaseBossDamage = equipment.itemBaseOption.itemBaseBossDamage,
+                itemBaseIgnoreMonsterArmor = equipment.itemBaseOption.itemBaseIgnoreMonsterArmor,
+                itemBaseAllStat = equipment.itemBaseOption.itemBaseAllStat,
+                itemBaseMaxHpRate = equipment.itemBaseOption.itemBaseMaxHpRate,
+                itemBaseMaxMpRate = equipment.itemBaseOption.itemBaseMaxMpRate,
+                itemBaseBaseEquipmentLevel = equipment.itemBaseOption.itemBaseBaseEquipmentLevel
+            )
+            val exceptionalOption = ItemExceptionalOption(
+                itemExceptionalStr = equipment.itemExceptionalOption.itemExceptionalStr,
+                itemExceptionalDex = equipment.itemExceptionalOption.itemExceptionalDex,
+                itemExceptionalInt = equipment.itemExceptionalOption.itemExceptionalInt,
+                itemExceptionalLuk = equipment.itemExceptionalOption.itemExceptionalLuk,
+                itemExceptionalMaxHp = equipment.itemExceptionalOption.itemExceptionalMaxHp,
+                itemExceptionalMaxMp = equipment.itemExceptionalOption.itemExceptionalMaxMp,
+                itemExceptionalAttackPower = equipment.itemExceptionalOption.itemExceptionalAttackPower,
+                itemExceptionalMagicPower = equipment.itemExceptionalOption.itemExceptionalMagicPower
+            )
+            val addOption = ItemAddOption(
+                itemAddStr = equipment.itemAddOption.itemAddStr,
+                itemAddDex = equipment.itemAddOption.itemAddDex,
+                itemAddInt = equipment.itemAddOption.itemAddInt,
+                itemAddLuk = equipment.itemAddOption.itemAddLuk,
+                itemAddMaxHp = equipment.itemAddOption.itemAddMaxHp,
+                itemAddMaxMp = equipment.itemAddOption.itemAddMaxMp,
+                itemAddAttackPower = equipment.itemAddOption.itemAddAttackPower,
+                itemAddMagicPower = equipment.itemAddOption.itemAddMagicPower,
+                itemAddArmor = equipment.itemAddOption.itemAddArmor,
+                itemAddSpeed = equipment.itemAddOption.itemAddSpeed,
+                itemAddJump = equipment.itemAddOption.itemAddJump,
+                itemAddBossDamage = equipment.itemAddOption.itemAddBossDamage,
+                itemAddDamage = equipment.itemAddOption.itemAddDamage,
+                itemAddAllStat = equipment.itemAddOption.itemAddAllStat,
+                itemAddEquipmentLevelDecrease = equipment.itemAddOption.itemAddEquipmentLevelDecrease
+            )
+            val etcOption = ItemEtcOption(
+                itemEtcStr = equipment.itemEtcOption.itemEtcStr,
+                itemEtcDex = equipment.itemEtcOption.itemEtcDex,
+                itemEtcInt = equipment.itemEtcOption.itemEtcInt,
+                itemEtcLuk = equipment.itemEtcOption.itemEtcLuk,
+                itemEtcMaxHp = equipment.itemEtcOption.itemEtcMaxHp,
+                itemEtcMaxMp = equipment.itemEtcOption.itemEtcMaxMp,
+                itemEtcAttackPower = equipment.itemEtcOption.itemEtcAttackPower,
+                itemEtcMagicPower = equipment.itemEtcOption.itemEtcMagicPower,
+                itemEtcArmor = equipment.itemEtcOption.itemEtcArmor,
+                itemEtcSpeed = equipment.itemEtcOption.itemEtcSpeed,
+                itemEtcJump = equipment.itemEtcOption.itemEtcJump
+            )
+            val starforceOption = ItemStarforceOption(
+                itemStarforceStr = equipment.itemStarforceOption.itemStarforceStr,
+                itemStarforceDex = equipment.itemStarforceOption.itemStarforceDex,
+                itemStarforceInt = equipment.itemStarforceOption.itemStarforceInt,
+                itemStarforceLuk = equipment.itemStarforceOption.itemStarforceLuk,
+                itemStarforceMaxHp = equipment.itemStarforceOption.itemStarforceMaxHp,
+                itemStarforceMaxMp = equipment.itemStarforceOption.itemStarforceMaxMp,
+                itemStarforceAttackPower = equipment.itemStarforceOption.itemStarforceAttackPower,
+                itemStarforceMagicPower = equipment.itemStarforceOption.itemStarforceMagicPower,
+                itemStarforceArmor = equipment.itemStarforceOption.itemStarforceArmor,
+                itemStarforceSpeed = equipment.itemStarforceOption.itemStarforceSpeed,
+                itemStarforceJump = equipment.itemStarforceOption.itemStarforceJump
+            )
+
+            itemEquipmentsSecondPreset.add(
+                ItemEquipment(
+                    itemEquipmentPart = equipment.itemEquipmentPart,
+                    equipmentSlot = equipment.equipmentSlot,
+                    itemName = equipment.itemName,
+                    itemIcon = equipment.itemIcon,
+                    itemDescription = equipment.itemDescription,
+                    itemShapeName = equipment.itemShapeName,
+                    itemShapeIcon = equipment.itemShapeIcon,
+                    itemGender = equipment.itemGender,
+                    itemTotalOption = totalOption,
+                    itemBaseOption = baseOption,
+                    potentialOptionGrade = equipment.potentialOptionGrade,
+                    additionalPotentialOptionGrade = equipment.additionalPotentialOptionGrade,
+                    potentialOptionFirst = equipment.potentialOptionFirst,
+                    potentialOptionSecond = equipment.potentialOptionSecond,
+                    potentialOptionThird = equipment.potentialOptionThird,
+                    additionalPotentialOptionFirst = equipment.additionalPotentialOptionFirst,
+                    additionalPotentialOptionSecond = equipment.additionalPotentialOptionSecond,
+                    additionalPotentialOptionThird = equipment.additionalPotentialOptionThird,
+                    equipmentLevelIncrease = equipment.equipmentLevelIncrease,
+                    itemExceptionalOption = exceptionalOption,
+                    itemAddOption = addOption,
+                    itemGrowthExp = equipment.itemGrowthExp,
+                    itemGrowthLevel = equipment.itemGrowthLevel,
+                    itemScrollUpgrade = equipment.itemScrollUpgrade,
+                    itemCuttableCount = equipment.itemCuttableCount,
+                    itemGoldenHammerFlag = equipment.itemGoldenHammerFlag,
+                    itemScrollResilienceCount = equipment.itemScrollResilienceCount,
+                    itemScrollUpgradableCount = equipment.itemScrollUpgradableCount,
+                    itemSoulName = equipment.itemSoulName,
+                    itemSoulOption = equipment.itemSoulOption,
+                    itemEtcOption = etcOption,
+                    itemStarforce = equipment.itemStarforce,
+                    itemStarforceScrollFlag = equipment.itemStarforceScrollFlag,
+                    itemStarforceOption = starforceOption,
+                    itemSpecialRingLevel = equipment.itemSpecialRingLevel,
+                    itemDateExpire = equipment.itemDateExpire
+                )
+            )
+        }
+
+        itemEquipmentEntity.itemEquipmentsThirdPreset.forEach { equipment ->
+            val totalOption = ItemTotalOption(
+                itemTotalStr = equipment.itemTotalOption.itemTotalStr,
+                itemTotalDex = equipment.itemTotalOption.itemTotalDex,
+                itemTotalInt = equipment.itemTotalOption.itemTotalInt,
+                itemTotalLuk = equipment.itemTotalOption.itemTotalLuk,
+                itemTotalMaxHp = equipment.itemTotalOption.itemTotalMaxHp,
+                itemTotalMaxMp = equipment.itemTotalOption.itemTotalMaxMp,
+                itemTotalAttackPower = equipment.itemTotalOption.itemTotalAttackPower,
+                itemTotalMagicPower = equipment.itemTotalOption.itemTotalMagicPower,
+                itemTotalArmor = equipment.itemTotalOption.itemTotalArmor,
+                itemTotalSpeed = equipment.itemTotalOption.itemTotalSpeed,
+                itemTotalJump = equipment.itemTotalOption.itemTotalJump,
+                itemTotalBossDamage = equipment.itemTotalOption.itemTotalBossDamage,
+                itemTotalIgnoreMonsterArmor = equipment.itemTotalOption.itemTotalIgnoreMonsterArmor,
+                itemTotalAllStat = equipment.itemTotalOption.itemTotalAllStat,
+                itemTotalDamage = equipment.itemTotalOption.itemTotalDamage,
+                itemTotalEquipmentLevelDecrease = equipment.itemTotalOption.itemTotalEquipmentLevelDecrease,
+                itemTotalMaxHpRate = equipment.itemTotalOption.itemTotalMaxHpRate,
+                itemTotalMaxMpRate = equipment.itemTotalOption.itemTotalMaxMpRate
+            )
+            val baseOption = ItemBaseOption(
+                itemBaseStr = equipment.itemBaseOption.itemBaseStr,
+                itemBaseDex = equipment.itemBaseOption.itemBaseDex,
+                itemBaseInt = equipment.itemBaseOption.itemBaseInt,
+                itemBaseLuk = equipment.itemBaseOption.itemBaseLuk,
+                itemBaseMaxHp = equipment.itemBaseOption.itemBaseMaxHp,
+                itemBaseMaxMp = equipment.itemBaseOption.itemBaseMaxMp,
+                itemBaseAttackPower = equipment.itemBaseOption.itemBaseAttackPower,
+                itemBaseMagicPower = equipment.itemBaseOption.itemBaseMagicPower,
+                itemBaseArmor = equipment.itemBaseOption.itemBaseArmor,
+                itemBaseSpeed = equipment.itemBaseOption.itemBaseSpeed,
+                itemBaseJump = equipment.itemBaseOption.itemBaseJump,
+                itemBaseBossDamage = equipment.itemBaseOption.itemBaseBossDamage,
+                itemBaseIgnoreMonsterArmor = equipment.itemBaseOption.itemBaseIgnoreMonsterArmor,
+                itemBaseAllStat = equipment.itemBaseOption.itemBaseAllStat,
+                itemBaseMaxHpRate = equipment.itemBaseOption.itemBaseMaxHpRate,
+                itemBaseMaxMpRate = equipment.itemBaseOption.itemBaseMaxMpRate,
+                itemBaseBaseEquipmentLevel = equipment.itemBaseOption.itemBaseBaseEquipmentLevel
+            )
+            val exceptionalOption = ItemExceptionalOption(
+                itemExceptionalStr = equipment.itemExceptionalOption.itemExceptionalStr,
+                itemExceptionalDex = equipment.itemExceptionalOption.itemExceptionalDex,
+                itemExceptionalInt = equipment.itemExceptionalOption.itemExceptionalInt,
+                itemExceptionalLuk = equipment.itemExceptionalOption.itemExceptionalLuk,
+                itemExceptionalMaxHp = equipment.itemExceptionalOption.itemExceptionalMaxHp,
+                itemExceptionalMaxMp = equipment.itemExceptionalOption.itemExceptionalMaxMp,
+                itemExceptionalAttackPower = equipment.itemExceptionalOption.itemExceptionalAttackPower,
+                itemExceptionalMagicPower = equipment.itemExceptionalOption.itemExceptionalMagicPower
+            )
+            val addOption = ItemAddOption(
+                itemAddStr = equipment.itemAddOption.itemAddStr,
+                itemAddDex = equipment.itemAddOption.itemAddDex,
+                itemAddInt = equipment.itemAddOption.itemAddInt,
+                itemAddLuk = equipment.itemAddOption.itemAddLuk,
+                itemAddMaxHp = equipment.itemAddOption.itemAddMaxHp,
+                itemAddMaxMp = equipment.itemAddOption.itemAddMaxMp,
+                itemAddAttackPower = equipment.itemAddOption.itemAddAttackPower,
+                itemAddMagicPower = equipment.itemAddOption.itemAddMagicPower,
+                itemAddArmor = equipment.itemAddOption.itemAddArmor,
+                itemAddSpeed = equipment.itemAddOption.itemAddSpeed,
+                itemAddJump = equipment.itemAddOption.itemAddJump,
+                itemAddBossDamage = equipment.itemAddOption.itemAddBossDamage,
+                itemAddDamage = equipment.itemAddOption.itemAddDamage,
+                itemAddAllStat = equipment.itemAddOption.itemAddAllStat,
+                itemAddEquipmentLevelDecrease = equipment.itemAddOption.itemAddEquipmentLevelDecrease
+            )
+            val etcOption = ItemEtcOption(
+                itemEtcStr = equipment.itemEtcOption.itemEtcStr,
+                itemEtcDex = equipment.itemEtcOption.itemEtcDex,
+                itemEtcInt = equipment.itemEtcOption.itemEtcInt,
+                itemEtcLuk = equipment.itemEtcOption.itemEtcLuk,
+                itemEtcMaxHp = equipment.itemEtcOption.itemEtcMaxHp,
+                itemEtcMaxMp = equipment.itemEtcOption.itemEtcMaxMp,
+                itemEtcAttackPower = equipment.itemEtcOption.itemEtcAttackPower,
+                itemEtcMagicPower = equipment.itemEtcOption.itemEtcMagicPower,
+                itemEtcArmor = equipment.itemEtcOption.itemEtcArmor,
+                itemEtcSpeed = equipment.itemEtcOption.itemEtcSpeed,
+                itemEtcJump = equipment.itemEtcOption.itemEtcJump
+            )
+            val starforceOption = ItemStarforceOption(
+                itemStarforceStr = equipment.itemStarforceOption.itemStarforceStr,
+                itemStarforceDex = equipment.itemStarforceOption.itemStarforceDex,
+                itemStarforceInt = equipment.itemStarforceOption.itemStarforceInt,
+                itemStarforceLuk = equipment.itemStarforceOption.itemStarforceLuk,
+                itemStarforceMaxHp = equipment.itemStarforceOption.itemStarforceMaxHp,
+                itemStarforceMaxMp = equipment.itemStarforceOption.itemStarforceMaxMp,
+                itemStarforceAttackPower = equipment.itemStarforceOption.itemStarforceAttackPower,
+                itemStarforceMagicPower = equipment.itemStarforceOption.itemStarforceMagicPower,
+                itemStarforceArmor = equipment.itemStarforceOption.itemStarforceArmor,
+                itemStarforceSpeed = equipment.itemStarforceOption.itemStarforceSpeed,
+                itemStarforceJump = equipment.itemStarforceOption.itemStarforceJump
+            )
+
+            itemEquipmentsThirdPreset.add(
+                ItemEquipment(
+                    itemEquipmentPart = equipment.itemEquipmentPart,
+                    equipmentSlot = equipment.equipmentSlot,
+                    itemName = equipment.itemName,
+                    itemIcon = equipment.itemIcon,
+                    itemDescription = equipment.itemDescription,
+                    itemShapeName = equipment.itemShapeName,
+                    itemShapeIcon = equipment.itemShapeIcon,
+                    itemGender = equipment.itemGender,
+                    itemTotalOption = totalOption,
+                    itemBaseOption = baseOption,
+                    potentialOptionGrade = equipment.potentialOptionGrade,
+                    additionalPotentialOptionGrade = equipment.additionalPotentialOptionGrade,
+                    potentialOptionFirst = equipment.potentialOptionFirst,
+                    potentialOptionSecond = equipment.potentialOptionSecond,
+                    potentialOptionThird = equipment.potentialOptionThird,
+                    additionalPotentialOptionFirst = equipment.additionalPotentialOptionFirst,
+                    additionalPotentialOptionSecond = equipment.additionalPotentialOptionSecond,
+                    additionalPotentialOptionThird = equipment.additionalPotentialOptionThird,
+                    equipmentLevelIncrease = equipment.equipmentLevelIncrease,
+                    itemExceptionalOption = exceptionalOption,
+                    itemAddOption = addOption,
+                    itemGrowthExp = equipment.itemGrowthExp,
+                    itemGrowthLevel = equipment.itemGrowthLevel,
+                    itemScrollUpgrade = equipment.itemScrollUpgrade,
+                    itemCuttableCount = equipment.itemCuttableCount,
+                    itemGoldenHammerFlag = equipment.itemGoldenHammerFlag,
+                    itemScrollResilienceCount = equipment.itemScrollResilienceCount,
+                    itemScrollUpgradableCount = equipment.itemScrollUpgradableCount,
+                    itemSoulName = equipment.itemSoulName,
+                    itemSoulOption = equipment.itemSoulOption,
+                    itemEtcOption = etcOption,
+                    itemStarforce = equipment.itemStarforce,
+                    itemStarforceScrollFlag = equipment.itemStarforceScrollFlag,
+                    itemStarforceOption = starforceOption,
+                    itemSpecialRingLevel = equipment.itemSpecialRingLevel,
+                    itemDateExpire = equipment.itemDateExpire
+                )
+            )
+        }
+
         return CharacterItemEquipment(
-            itemEquipments = itemEquipmentEntity.itemEquipments,
-            itemTitle = itemEquipmentEntity.itemTitle
+            itemEquipments = itemEquipments,
+            itemEquipmentsFirstPreset = itemEquipmentsFirstPreset,
+            itemEquipmentsSecondPreset = itemEquipmentsSecondPreset,
+            itemEquipmentsThirdPreset = itemEquipmentsThirdPreset,
+            itemTitle = itemTitle
         )
     }
 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/mapper/CharacterStatMapper.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/mapper/CharacterStatMapper.kt
@@ -6,6 +6,12 @@ import com.bodan.maplecalendar.data.model.StatEntity
 object CharacterStatMapper {
 
     operator fun invoke(statEntity: StatEntity): List<FinalStat> {
-        return statEntity.finalStats
+        val result = mutableListOf<FinalStat>()
+
+        statEntity.finalStats.forEach { stat ->
+            result.add(FinalStat(statName = stat.statName, statValue = stat.statValue))
+        }
+
+        return result
     }
 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/model/MaplestoryEntity.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/model/MaplestoryEntity.kt
@@ -1,9 +1,6 @@
 package com.bodan.maplecalendar.data.model
 
 import androidx.annotation.Keep
-import com.bodan.maplecalendar.domain.entity.FinalStat
-import com.bodan.maplecalendar.domain.entity.ItemEquipment
-import com.bodan.maplecalendar.domain.entity.ItemTitle
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
@@ -43,17 +40,431 @@ data class BasicEntity(
 @JsonClass(generateAdapter = true)
 data class StatEntity(
     @Json(name = "final_stat")
-    val finalStats: List<FinalStat>
+    val finalStats: List<FinalStatEntity>
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class FinalStatEntity(
+    @Json(name = "stat_name")
+    val statName: String,
+
+    @Json(name = "stat_value")
+    val statValue: String?
 )
 
 @Keep
 @JsonClass(generateAdapter = true)
 data class ItemEquipmentEntity(
     @Json(name = "item_equipment")
-    val itemEquipments: List<ItemEquipment>,
+    val itemEquipments: List<EquipmentEntity>,
+
+    @Json(name = "item_equipment_preset_1")
+    val itemEquipmentsFirstPreset: List<EquipmentEntity>,
+
+    @Json(name = "item_equipment_preset_2")
+    val itemEquipmentsSecondPreset: List<EquipmentEntity>,
+
+    @Json(name = "item_equipment_preset_3")
+    val itemEquipmentsThirdPreset: List<EquipmentEntity>,
 
     @Json(name = "title")
-    val itemTitle: ItemTitle?
+    val itemTitle: TitleEntity?
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class EquipmentEntity(
+    @Json(name = "item_equipment_part")
+    val itemEquipmentPart: String,
+
+    @Json(name = "item_equipment_slot")
+    val equipmentSlot: String,
+
+    @Json(name = "item_name")
+    val itemName: String,
+
+    @Json(name = "item_icon")
+    val itemIcon: String,
+
+    @Json(name = "item_description")
+    val itemDescription: String?,
+
+    @Json(name = "item_shape_name")
+    val itemShapeName: String,
+
+    @Json(name = "item_shape_icon")
+    val itemShapeIcon: String,
+
+    @Json(name = "item_gender")
+    val itemGender: String?,
+
+    @Json(name = "item_total_option")
+    val itemTotalOption: TotalOptionEntity,
+
+    @Json(name = "item_base_option")
+    val itemBaseOption: BaseOptionEntity,
+
+    @Json(name = "potential_option_grade")
+    val potentialOptionGrade: String?,
+
+    @Json(name = "additional_potential_option_grade")
+    val additionalPotentialOptionGrade: String?,
+
+    @Json(name = "potential_option_1")
+    val potentialOptionFirst: String?,
+
+    @Json(name = "potential_option_2")
+    val potentialOptionSecond: String?,
+
+    @Json(name = "potential_option_3")
+    val potentialOptionThird: String?,
+
+    @Json(name = "additional_potential_option_1")
+    val additionalPotentialOptionFirst: String?,
+
+    @Json(name = "additional_potential_option_2")
+    val additionalPotentialOptionSecond: String?,
+
+    @Json(name = "additional_potential_option_3")
+    val additionalPotentialOptionThird: String?,
+
+    @Json(name = "equipment_level_increase")
+    val equipmentLevelIncrease: String,
+
+    @Json(name = "item_exceptional_option")
+    val itemExceptionalOption: ExceptionalOptionEntity,
+
+    @Json(name = "item_add_option")
+    val itemAddOption: AddOptionEntity,
+
+    @Json(name = "growth_exp")
+    val itemGrowthExp: Int,
+
+    @Json(name = "growth_level")
+    val itemGrowthLevel: Int,
+
+    @Json(name = "scroll_upgrade")
+    val itemScrollUpgrade: String,
+
+    @Json(name = "cuttable_count")
+    val itemCuttableCount: String,
+
+    @Json(name = "golden_hammer_flag")
+    val itemGoldenHammerFlag: String,
+
+    @Json(name = "scroll_resilience_count")
+    val itemScrollResilienceCount: String,
+
+    @Json(name = "scroll_upgradeable_count")
+    val itemScrollUpgradableCount: String,
+
+    @Json(name = "soul_name")
+    val itemSoulName: String?,
+
+    @Json(name = "soul_option")
+    val itemSoulOption: String?,
+
+    @Json(name = "item_etc_option")
+    val itemEtcOption: EtcOptionEntity,
+
+    @Json(name = "starforce")
+    val itemStarforce: String,
+
+    @Json(name = "starforce_scroll_flag")
+    val itemStarforceScrollFlag: String,
+
+    @Json(name = "item_starforce_option")
+    val itemStarforceOption: StarforceOptionEntity,
+
+    @Json(name = "special_ring_level")
+    val itemSpecialRingLevel: Int,
+
+    @Json(name = "date_expire")
+    val itemDateExpire: String?
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class TotalOptionEntity(
+    @Json(name = "str")
+    val itemTotalStr: String = "",
+
+    @Json(name = "dex")
+    val itemTotalDex: String = "",
+
+    @Json(name = "int")
+    val itemTotalInt: String = "",
+
+    @Json(name = "luk")
+    val itemTotalLuk: String = "",
+
+    @Json(name = "max_hp")
+    val itemTotalMaxHp: String = "",
+
+    @Json(name = "max_mp")
+    val itemTotalMaxMp: String = "",
+
+    @Json(name = "attack_power")
+    val itemTotalAttackPower: String = "",
+
+    @Json(name = "magic_power")
+    val itemTotalMagicPower: String = "",
+
+    @Json(name = "armor")
+    val itemTotalArmor: String = "",
+
+    @Json(name = "speed")
+    val itemTotalSpeed: String = "",
+
+    @Json(name = "jump")
+    val itemTotalJump: String = "",
+
+    @Json(name = "boss_damage")
+    val itemTotalBossDamage: String = "",
+
+    @Json(name = "ignore_monster_armor")
+    val itemTotalIgnoreMonsterArmor: String = "",
+
+    @Json(name = "all_stat")
+    val itemTotalAllStat: String = "",
+
+    @Json(name = "damage")
+    val itemTotalDamage: String = "",
+
+    @Json(name = "equipment_level_decrease")
+    val itemTotalEquipmentLevelDecrease: String = "",
+
+    @Json(name = "max_hp_rate")
+    val itemTotalMaxHpRate: String = "",
+
+    @Json(name = "max_mp_rate")
+    val itemTotalMaxMpRate: String = ""
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class BaseOptionEntity(
+    @Json(name = "str")
+    val itemBaseStr: String = "",
+
+    @Json(name = "dex")
+    val itemBaseDex: String = "",
+
+    @Json(name = "int")
+    val itemBaseInt: String = "",
+
+    @Json(name = "luk")
+    val itemBaseLuk: String = "",
+
+    @Json(name = "max_hp")
+    val itemBaseMaxHp: String = "",
+
+    @Json(name = "max_mp")
+    val itemBaseMaxMp: String = "",
+
+    @Json(name = "attack_power")
+    val itemBaseAttackPower: String = "",
+
+    @Json(name = "magic_power")
+    val itemBaseMagicPower: String = "",
+
+    @Json(name = "armor")
+    val itemBaseArmor: String = "",
+
+    @Json(name = "speed")
+    val itemBaseSpeed: String = "",
+
+    @Json(name = "jump")
+    val itemBaseJump: String = "",
+
+    @Json(name = "boss_damage")
+    val itemBaseBossDamage: String = "",
+
+    @Json(name = "ignore_monster_armor")
+    val itemBaseIgnoreMonsterArmor: String = "",
+
+    @Json(name = "all_stat")
+    val itemBaseAllStat: String = "",
+
+    @Json(name = "max_hp_rate")
+    val itemBaseMaxHpRate: String = "",
+
+    @Json(name = "max_mp_rate")
+    val itemBaseMaxMpRate: String = "",
+
+    @Json(name = "base_equipment_level")
+    val itemBaseBaseEquipmentLevel: String = "",
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class ExceptionalOptionEntity(
+    @Json(name = "str")
+    val itemExceptionalStr: String = "",
+
+    @Json(name = "dex")
+    val itemExceptionalDex: String = "",
+
+    @Json(name = "int")
+    val itemExceptionalInt: String = "",
+
+    @Json(name = "luk")
+    val itemExceptionalLuk: String = "",
+
+    @Json(name = "max_hp")
+    val itemExceptionalMaxHp: String = "",
+
+    @Json(name = "max_mp")
+    val itemExceptionalMaxMp: String = "",
+
+    @Json(name = "attack_power")
+    val itemExceptionalAttackPower: String = "",
+
+    @Json(name = "magic_power")
+    val itemExceptionalMagicPower: String = "",
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class AddOptionEntity(
+    @Json(name = "str")
+    val itemAddStr: String = "",
+
+    @Json(name = "dex")
+    val itemAddDex: String = "",
+
+    @Json(name = "int")
+    val itemAddInt: String = "",
+
+    @Json(name = "luk")
+    val itemAddLuk: String = "",
+
+    @Json(name = "max_hp")
+    val itemAddMaxHp: String = "",
+
+    @Json(name = "max_mp")
+    val itemAddMaxMp: String = "",
+
+    @Json(name = "attack_power")
+    val itemAddAttackPower: String = "",
+
+    @Json(name = "magic_power")
+    val itemAddMagicPower: String = "",
+
+    @Json(name = "armor")
+    val itemAddArmor: String = "",
+
+    @Json(name = "speed")
+    val itemAddSpeed: String = "",
+
+    @Json(name = "jump")
+    val itemAddJump: String = "",
+
+    @Json(name = "boss_damage")
+    val itemAddBossDamage: String = "",
+
+    @Json(name = "damage")
+    val itemAddDamage: String = "",
+
+    @Json(name = "all_stat")
+    val itemAddAllStat: String = "",
+
+    @Json(name = "equipment_level_decrease")
+    val itemAddEquipmentLevelDecrease: String = "",
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class StarforceOptionEntity(
+    @Json(name = "str")
+    val itemStarforceStr: String = "",
+
+    @Json(name = "dex")
+    val itemStarforceDex: String = "",
+
+    @Json(name = "int")
+    val itemStarforceInt: String = "",
+
+    @Json(name = "luk")
+    val itemStarforceLuk: String = "",
+
+    @Json(name = "max_hp")
+    val itemStarforceMaxHp: String = "",
+
+    @Json(name = "max_mp")
+    val itemStarforceMaxMp: String = "",
+
+    @Json(name = "attack_power")
+    val itemStarforceAttackPower: String = "",
+
+    @Json(name = "magic_power")
+    val itemStarforceMagicPower: String = "",
+
+    @Json(name = "armor")
+    val itemStarforceArmor: String = "",
+
+    @Json(name = "speed")
+    val itemStarforceSpeed: String = "",
+
+    @Json(name = "jump")
+    val itemStarforceJump: String = ""
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class EtcOptionEntity(
+    @Json(name = "str")
+    val itemEtcStr: String = "",
+
+    @Json(name = "dex")
+    val itemEtcDex: String = "",
+
+    @Json(name = "int")
+    val itemEtcInt: String = "",
+
+    @Json(name = "luk")
+    val itemEtcLuk: String = "",
+
+    @Json(name = "max_hp")
+    val itemEtcMaxHp: String = "",
+
+    @Json(name = "max_mp")
+    val itemEtcMaxMp: String = "",
+
+    @Json(name = "attack_power")
+    val itemEtcAttackPower: String = "",
+
+    @Json(name = "magic_power")
+    val itemEtcMagicPower: String = "",
+
+    @Json(name = "armor")
+    val itemEtcArmor: String = "",
+
+    @Json(name = "speed")
+    val itemEtcSpeed: String = "",
+
+    @Json(name = "jump")
+    val itemEtcJump: String = ""
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class TitleEntity(
+    @Json(name = "title_name")
+    val itemTitleName: String,
+
+    @Json(name = "title_icon")
+    val itemTitleIcon: String,
+
+    @Json(name = "title_description")
+    val itemTitleDescription: String,
+
+    @Json(name = "date_expire")
+    val itemTitleDateExpire: String?,
+
+    @Json(name = "date_option_expire")
+    val itemTitleDateOptionExpire: String?
 )
 
 @Keep

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterItemEquipment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterItemEquipment.kt
@@ -5,5 +5,8 @@ import androidx.annotation.Keep
 @Keep
 data class CharacterItemEquipment(
     val itemEquipments: List<ItemEquipment>,
+    val itemEquipmentsFirstPreset: List<ItemEquipment>,
+    val itemEquipmentsSecondPreset: List<ItemEquipment>,
+    val itemEquipmentsThirdPreset: List<ItemEquipment>,
     val itemTitle: ItemTitle?
 )

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/FinalStat.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/FinalStat.kt
@@ -1,15 +1,9 @@
 package com.bodan.maplecalendar.domain.entity
 
 import androidx.annotation.Keep
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
 
 @Keep
-@JsonClass(generateAdapter = true)
 data class FinalStat(
-    @Json(name = "stat_name")
     val statName: String,
-
-    @Json(name = "stat_value")
     val statValue: String?
 )

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemAddOption.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemAddOption.kt
@@ -1,54 +1,22 @@
 package com.bodan.maplecalendar.domain.entity
 
 import androidx.annotation.Keep
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
 
 @Keep
-@JsonClass(generateAdapter = true)
 data class ItemAddOption(
-    @Json(name = "str")
     val itemAddStr: String = "",
-
-    @Json(name = "dex")
     val itemAddDex: String = "",
-
-    @Json(name = "int")
     val itemAddInt: String = "",
-
-    @Json(name = "luk")
     val itemAddLuk: String = "",
-
-    @Json(name = "max_hp")
     val itemAddMaxHp: String = "",
-
-    @Json(name = "max_mp")
     val itemAddMaxMp: String = "",
-
-    @Json(name = "attack_power")
     val itemAddAttackPower: String = "",
-
-    @Json(name = "magic_power")
     val itemAddMagicPower: String = "",
-
-    @Json(name = "armor")
     val itemAddArmor: String = "",
-
-    @Json(name = "speed")
     val itemAddSpeed: String = "",
-
-    @Json(name = "jump")
     val itemAddJump: String = "",
-
-    @Json(name = "boss_damage")
     val itemAddBossDamage: String = "",
-
-    @Json(name = "damage")
     val itemAddDamage: String = "",
-
-    @Json(name = "all_stat")
     val itemAddAllStat: String = "",
-
-    @Json(name = "equipment_level_decrease")
     val itemAddEquipmentLevelDecrease: String = "",
 )

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemBaseOption.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemBaseOption.kt
@@ -1,60 +1,24 @@
 package com.bodan.maplecalendar.domain.entity
 
 import androidx.annotation.Keep
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
 
 @Keep
-@JsonClass(generateAdapter = true)
 data class ItemBaseOption(
-    @Json(name = "str")
     val itemBaseStr: String = "",
-
-    @Json(name = "dex")
     val itemBaseDex: String = "",
-
-    @Json(name = "int")
     val itemBaseInt: String = "",
-
-    @Json(name = "luk")
     val itemBaseLuk: String = "",
-
-    @Json(name = "max_hp")
     val itemBaseMaxHp: String = "",
-
-    @Json(name = "max_mp")
     val itemBaseMaxMp: String = "",
-
-    @Json(name = "attack_power")
     val itemBaseAttackPower: String = "",
-
-    @Json(name = "magic_power")
     val itemBaseMagicPower: String = "",
-
-    @Json(name = "armor")
     val itemBaseArmor: String = "",
-
-    @Json(name = "speed")
     val itemBaseSpeed: String = "",
-
-    @Json(name = "jump")
     val itemBaseJump: String = "",
-
-    @Json(name = "boss_damage")
     val itemBaseBossDamage: String = "",
-
-    @Json(name = "ignore_monster_armor")
     val itemBaseIgnoreMonsterArmor: String = "",
-
-    @Json(name = "all_stat")
     val itemBaseAllStat: String = "",
-
-    @Json(name = "max_hp_rate")
     val itemBaseMaxHpRate: String = "",
-
-    @Json(name = "max_mp_rate")
     val itemBaseMaxMpRate: String = "",
-
-    @Json(name = "base_equipment_level")
     val itemBaseBaseEquipmentLevel: String = "",
 )

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemEquipment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemEquipment.kt
@@ -1,117 +1,43 @@
 package com.bodan.maplecalendar.domain.entity
 
 import androidx.annotation.Keep
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
 
 @Keep
-@JsonClass(generateAdapter = true)
 data class ItemEquipment(
-    @Json(name = "item_equipment_part")
     val itemEquipmentPart: String,
-
-    @Json(name = "item_equipment_slot")
     val equipmentSlot: String,
-
-    @Json(name = "item_name")
     val itemName: String,
-
-    @Json(name = "item_icon")
     val itemIcon: String,
-
-    @Json(name = "item_description")
     val itemDescription: String?,
-
-    @Json(name = "item_shape_name")
     val itemShapeName: String,
-
-    @Json(name = "item_shape_icon")
     val itemShapeIcon: String,
-
-    @Json(name = "item_gender")
     val itemGender: String?,
-
-    @Json(name = "item_total_option")
     val itemTotalOption: ItemTotalOption,
-
-    @Json(name = "item_base_option")
     val itemBaseOption: ItemBaseOption,
-
-    @Json(name = "potential_option_grade")
     val potentialOptionGrade: String?,
-
-    @Json(name = "additional_potential_option_grade")
     val additionalPotentialOptionGrade: String?,
-
-    @Json(name = "potential_option_1")
     val potentialOptionFirst: String?,
-
-    @Json(name = "potential_option_2")
     val potentialOptionSecond: String?,
-
-    @Json(name = "potential_option_3")
     val potentialOptionThird: String?,
-
-    @Json(name = "additional_potential_option_1")
     val additionalPotentialOptionFirst: String?,
-
-    @Json(name = "additional_potential_option_2")
     val additionalPotentialOptionSecond: String?,
-
-    @Json(name = "additional_potential_option_3")
     val additionalPotentialOptionThird: String?,
-
-    @Json(name = "equipment_level_increase")
     val equipmentLevelIncrease: String,
-
-    @Json(name = "item_exceptional_option")
     val itemExceptionalOption: ItemExceptionalOption,
-
-    @Json(name = "item_add_option")
     val itemAddOption: ItemAddOption,
-
-    @Json(name = "growth_exp")
     val itemGrowthExp: Int,
-
-    @Json(name = "growth_level")
     val itemGrowthLevel: Int,
-
-    @Json(name = "scroll_upgrade")
     val itemScrollUpgrade: String,
-
-    @Json(name = "cuttable_count")
     val itemCuttableCount: String,
-
-    @Json(name = "golden_hammer_flag")
     val itemGoldenHammerFlag: String,
-
-    @Json(name = "scroll_resilience_count")
     val itemScrollResilienceCount: String,
-
-    @Json(name = "scroll_upgradeable_count")
     val itemScrollUpgradableCount: String,
-
-    @Json(name = "soul_name")
     val itemSoulName: String?,
-
-    @Json(name = "soul_option")
     val itemSoulOption: String?,
-
-    @Json(name = "item_etc_option")
     val itemEtcOption: ItemEtcOption,
-
-    @Json(name = "starforce")
     val itemStarforce: String,
-
-    @Json(name = "starforce_scroll_flag")
     val itemStarforceScrollFlag: String,
-
-    @Json(name = "item_starforce_option")
     val itemStarforceOption: ItemStarforceOption,
-
-    @Json(name = "special_ring_level")
     val itemSpecialRingLevel: Int,
-
-    @Json(name = "date_expire")
     val itemDateExpire: String?
 )

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemEtcOption.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemEtcOption.kt
@@ -1,42 +1,18 @@
 package com.bodan.maplecalendar.domain.entity
 
 import androidx.annotation.Keep
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
 
 @Keep
-@JsonClass(generateAdapter = true)
 data class ItemEtcOption(
-    @Json(name = "str")
     val itemEtcStr: String = "",
-
-    @Json(name = "dex")
     val itemEtcDex: String = "",
-
-    @Json(name = "int")
     val itemEtcInt: String = "",
-
-    @Json(name = "luk")
     val itemEtcLuk: String = "",
-
-    @Json(name = "max_hp")
     val itemEtcMaxHp: String = "",
-
-    @Json(name = "max_mp")
     val itemEtcMaxMp: String = "",
-
-    @Json(name = "attack_power")
     val itemEtcAttackPower: String = "",
-
-    @Json(name = "magic_power")
     val itemEtcMagicPower: String = "",
-
-    @Json(name = "armor")
     val itemEtcArmor: String = "",
-
-    @Json(name = "speed")
     val itemEtcSpeed: String = "",
-
-    @Json(name = "jump")
     val itemEtcJump: String = ""
 )

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemExceptionalOption.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemExceptionalOption.kt
@@ -1,33 +1,15 @@
 package com.bodan.maplecalendar.domain.entity
 
 import androidx.annotation.Keep
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
 
 @Keep
-@JsonClass(generateAdapter = true)
 data class ItemExceptionalOption(
-    @Json(name = "str")
     val itemExceptionalStr: String = "",
-
-    @Json(name = "dex")
     val itemExceptionalDex: String = "",
-
-    @Json(name = "int")
     val itemExceptionalInt: String = "",
-
-    @Json(name = "luk")
     val itemExceptionalLuk: String = "",
-
-    @Json(name = "max_hp")
     val itemExceptionalMaxHp: String = "",
-
-    @Json(name = "max_mp")
     val itemExceptionalMaxMp: String = "",
-
-    @Json(name = "attack_power")
     val itemExceptionalAttackPower: String = "",
-
-    @Json(name = "magic_power")
     val itemExceptionalMagicPower: String = "",
 )

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemStarforceOption.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemStarforceOption.kt
@@ -1,42 +1,18 @@
 package com.bodan.maplecalendar.domain.entity
 
 import androidx.annotation.Keep
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
 
 @Keep
-@JsonClass(generateAdapter = true)
 data class ItemStarforceOption(
-    @Json(name = "str")
     val itemStarforceStr: String = "",
-
-    @Json(name = "dex")
     val itemStarforceDex: String = "",
-
-    @Json(name = "int")
     val itemStarforceInt: String = "",
-
-    @Json(name = "luk")
     val itemStarforceLuk: String = "",
-
-    @Json(name = "max_hp")
     val itemStarforceMaxHp: String = "",
-
-    @Json(name = "max_mp")
     val itemStarforceMaxMp: String = "",
-
-    @Json(name = "attack_power")
     val itemStarforceAttackPower: String = "",
-
-    @Json(name = "magic_power")
     val itemStarforceMagicPower: String = "",
-
-    @Json(name = "armor")
     val itemStarforceArmor: String = "",
-
-    @Json(name = "speed")
     val itemStarforceSpeed: String = "",
-
-    @Json(name = "jump")
     val itemStarforceJump: String = ""
 )

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemTitle.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemTitle.kt
@@ -1,24 +1,12 @@
 package com.bodan.maplecalendar.domain.entity
 
 import androidx.annotation.Keep
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
 
 @Keep
-@JsonClass(generateAdapter = true)
 data class ItemTitle(
-    @Json(name = "title_name")
     val itemTitleName: String,
-
-    @Json(name = "title_icon")
     val itemTitleIcon: String,
-
-    @Json(name = "title_description")
     val itemTitleDescription: String,
-
-    @Json(name = "date_expire")
     val itemTitleDateExpire: String?,
-
-    @Json(name = "date_option_expire")
     val itemTitleDateOptionExpire: String?
 )

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemTotalOption.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemTotalOption.kt
@@ -1,63 +1,25 @@
 package com.bodan.maplecalendar.domain.entity
 
 import androidx.annotation.Keep
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
 
 @Keep
-@JsonClass(generateAdapter = true)
 data class ItemTotalOption(
-    @Json(name = "str")
     val itemTotalStr: String = "",
-
-    @Json(name = "dex")
     val itemTotalDex: String = "",
-
-    @Json(name = "int")
     val itemTotalInt: String = "",
-
-    @Json(name = "luk")
     val itemTotalLuk: String = "",
-
-    @Json(name = "max_hp")
     val itemTotalMaxHp: String = "",
-
-    @Json(name = "max_mp")
     val itemTotalMaxMp: String = "",
-
-    @Json(name = "attack_power")
     val itemTotalAttackPower: String = "",
-
-    @Json(name = "magic_power")
     val itemTotalMagicPower: String = "",
-
-    @Json(name = "armor")
     val itemTotalArmor: String = "",
-
-    @Json(name = "speed")
     val itemTotalSpeed: String = "",
-
-    @Json(name = "jump")
     val itemTotalJump: String = "",
-
-    @Json(name = "boss_damage")
     val itemTotalBossDamage: String = "",
-
-    @Json(name = "ignore_monster_armor")
     val itemTotalIgnoreMonsterArmor: String = "",
-
-    @Json(name = "all_stat")
     val itemTotalAllStat: String = "",
-
-    @Json(name = "damage")
     val itemTotalDamage: String = "",
-
-    @Json(name = "equipment_level_decrease")
     val itemTotalEquipmentLevelDecrease: String = "",
-
-    @Json(name = "max_hp_rate")
     val itemTotalMaxHpRate: String = "",
-
-    @Json(name = "max_mp_rate")
     val itemTotalMaxMpRate: String = ""
 )

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentFragment.kt
@@ -64,5 +64,7 @@ class EquipmentFragment : BaseFragment<FragmentEquipmentBinding>(R.layout.fragme
         is EquipmentUiEvent.SetDarkMode -> {
             setDarkMode()
         }
+
+        else -> {}
     }
 }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentUiEvent.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentUiEvent.kt
@@ -4,6 +4,8 @@ sealed class EquipmentUiEvent {
 
     data object GetItemEquipmentOption : EquipmentUiEvent()
 
+    data object CloseItemEquipmentDetail : EquipmentUiEvent()
+
     data object BadRequest : EquipmentUiEvent()
 
     data object UnauthorizedStatus : EquipmentUiEvent()

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentUiState.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentUiState.kt
@@ -338,6 +338,18 @@ sealed class EquipmentUiState(val id: String = UUID.randomUUID().toString()) {
 
                                 false -> {
                                     when {
+                                        itemName.contains("크로스 링") -> return 0
+
+                                        itemName.contains("엔젤릭 블레스") -> return 0
+
+                                        itemName.contains("시그너스의 코히누르") -> return 0
+
+                                        itemName.contains("앱솔루트 링") -> return 0
+
+                                        itemName.contains("퍼스트 링") -> return 0
+
+                                        itemName.contains("오로라 링") -> return 0
+
                                         itemName.contains("오닉스 링") -> return 0
 
                                         itemName.contains("벤전스 링") -> return 0
@@ -364,7 +376,9 @@ sealed class EquipmentUiState(val id: String = UUID.randomUUID().toString()) {
 
                                         itemName.contains("크리티컬링") -> return 0
 
-                                        itemName.contains("정령의 펜던트") -> return 0
+                                        itemName.contains("오닉스 펜던트") -> return 0
+
+                                        !isAbleToUpgrade -> return 0
 
                                         else -> {
                                             return when (itemBaseOption.itemBaseBaseEquipmentLevel.toInt()) {

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/ItemEquipmentDetailFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/ItemEquipmentDetailFragment.kt
@@ -3,11 +3,14 @@ package com.bodan.maplecalendar.presentation.views.equipment
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import com.bodan.maplecalendar.R
 import com.bodan.maplecalendar.databinding.FragmentItemEquipmentDetailBinding
 import com.bodan.maplecalendar.presentation.config.BaseDialogFragment
 import com.bodan.maplecalendar.presentation.views.CharacterViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class ItemEquipmentDetailFragment :
@@ -24,6 +27,27 @@ class ItemEquipmentDetailFragment :
 
         binding.vm = viewModel
         binding.listAdapter = itemEquipmentDetailOptionListAdapter
+
+        initStarforce()
+
+        isCancelable = false
+
+        lifecycleScope.launch {
+            viewModel.equipmentUiEvent.collectLatest { uiEvent ->
+                if (uiEvent == EquipmentUiEvent.CloseItemEquipmentDetail) dismiss()
+            }
+        }
+    }
+
+    private fun initListAdapter() {
+        itemEquipmentDetailOptionListAdapter = ItemEquipmentDetailOptionListAdapter()
+    }
+
+    private fun initRecyclerView() {
+        binding.rvOptionItemEquipmentDetail.setHasFixedSize(false)
+    }
+
+    private fun initStarforce() {
         viewModel.characterLastItemEquipment.value?.let { itemEquipment ->
             if (itemEquipment.maxStarforceValue >= 1) {
                 binding.starforceFirstItemEquipmentDetail.initStarforceView(
@@ -39,13 +63,5 @@ class ItemEquipmentDetailFragment :
                 )
             }
         }
-    }
-
-    private fun initListAdapter() {
-        itemEquipmentDetailOptionListAdapter = ItemEquipmentDetailOptionListAdapter()
-    }
-
-    private fun initRecyclerView() {
-        binding.rvOptionItemEquipmentDetail.setHasFixedSize(false)
     }
 }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/OnItemEquipmentClickListener.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/OnItemEquipmentClickListener.kt
@@ -3,4 +3,6 @@ package com.bodan.maplecalendar.presentation.views.equipment
 interface OnItemEquipmentClickListener {
 
     fun onItemEquipmentClicked(item: EquipmentUiState.EquipmentOption)
+
+    fun onItemEquipmentDetailClicked()
 }

--- a/app/src/main/res/layout/fragment_equipment.xml
+++ b/app/src/main/res/layout/fragment_equipment.xml
@@ -52,13 +52,79 @@
                 android:nestedScrollingEnabled="false"
                 android:padding="12dp"
                 app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/mcv_equipment"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/tv_title_equipment"
                 app:spanCount="5"
                 app:submitData="@{vm.characterItemEquipmentData}"
                 tools:listitem="@layout/item_equipment_option" />
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/mcv_equipment"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:layout_marginEnd="12dp"
+                android:layout_marginBottom="12dp"
+                app:cardCornerRadius="1dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/rv_equipment"
+                app:strokeWidth="0dp">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/equipment_background"
+                    android:padding="2dp">
+
+                    <androidx.appcompat.widget.AppCompatButton
+                        android:id="@+id/ib_preset_first_equipment"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="4dp"
+                        android:background="@{(vm.characterItemEquipmentPreset == 1) ? @color/equipment_legendary : @color/level}"
+                        android:fontFamily="@font/pretendardregular"
+                        android:onClick="@{() -> vm.getCharacterEquipmentFirstPreset()}"
+                        android:text="@string/text_preset_1"
+                        android:textSize="11sp"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/ib_preset_second_equipment"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <androidx.appcompat.widget.AppCompatButton
+                        android:id="@+id/ib_preset_second_equipment"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="4dp"
+                        android:background="@{(vm.characterItemEquipmentPreset == 2) ? @color/equipment_legendary : @color/level}"
+                        android:fontFamily="@font/pretendardregular"
+                        android:onClick="@{() -> vm.getCharacterEquipmentSecondPreset()}"
+                        android:text="@string/text_preset_2"
+                        android:textSize="11sp"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/ib_preset_third_equipment"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <androidx.appcompat.widget.AppCompatButton
+                        android:id="@+id/ib_preset_third_equipment"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="4dp"
+                        android:background="@{(vm.characterItemEquipmentPreset == 3) ? @color/equipment_legendary : @color/level}"
+                        android:fontFamily="@font/pretendardregular"
+                        android:onClick="@{() -> vm.getCharacterEquipmentThirdPreset()}"
+                        android:text="@string/text_preset_3"
+                        android:textSize="11sp"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </com.google.android.material.card.MaterialCardView>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_item_equipment_detail.xml
+++ b/app/src/main/res/layout/fragment_item_equipment_detail.xml
@@ -15,6 +15,10 @@
             name="listAdapter"
             type="com.bodan.maplecalendar.presentation.views.equipment.ItemEquipmentDetailOptionListAdapter" />
 
+        <variable
+            name="onItemEquipmentClickListener"
+            type="com.bodan.maplecalendar.presentation.views.equipment.OnItemEquipmentClickListener" />
+
     </data>
 
     <LinearLayout
@@ -29,7 +33,8 @@
                 android:layout_width="330dp"
                 android:layout_height="wrap_content"
                 android:background="@drawable/shape_equipment_detail"
-                android:paddingBottom="16dp"
+                android:onClick="@{() -> vm.onItemEquipmentDetailClicked()}"
+                android:paddingBottom="24dp"
                 android:visibility="@{(vm.characterLastItemEquipment == null) ? View.GONE : View.VISIBLE}"
                 tools:context=".presentation.equipment.ItemEquipmentDetailFragment">
 
@@ -229,7 +234,7 @@
                     android:textColor="@color/level"
                     android:textSize="11sp"
                     app:layout_constraintBottom_toBottomOf="@id/tv_req_str_item_equipment_detail"
-                    app:layout_constraintStart_toEndOf="@id/tv_req_str_item_equipment_detail"
+                    app:layout_constraintEnd_toEndOf="@id/tv_req_dex_stat_item_equipment_detail"
                     app:layout_constraintTop_toTopOf="@id/tv_req_str_item_equipment_detail" />
 
                 <TextView
@@ -443,6 +448,7 @@
                     android:layout_height="wrap_content"
                     android:adapter="@{listAdapter}"
                     android:nestedScrollingEnabled="false"
+                    android:onClick="@{() -> vm.onItemEquipmentDetailClicked()}"
                     android:orientation="vertical"
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintBottom_toTopOf="@id/tv_upgrade_count_item_equipment_detail"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,9 @@
     <string name="text_character_stance">스탠스</string>
     <string name="text_character_attack_speed">공격 속도</string>
     <string name="text_title_equipment">EQUIPMENT INVENTORY</string>
+    <string name="text_preset_1">PRESET 1</string>
+    <string name="text_preset_2">PRESET 2</string>
+    <string name="text_preset_3">PRESET 3</string>
     <string name="text_rare_item">레어 아이템</string>
     <string name="text_epic_item">에픽 아이템</string>
     <string name="text_unique_item">유니크 아이템</string>


### PR DESCRIPTION
# 2024. 05. 09
## 💭 Motivation
#### 장비 프리셋을 받아오도록 하기 위하여 작업을 하였다.

## 🔧 Changed
#### 장비 프리셋 받아오기
 - PRESET 1, 2, 3번 버튼을 터치하여 해당 프리셋에 있는 장비 확인 가능

#### 아이템 연속 터치 시 App이 팅기는 현상 방지
 - 아이템을 터치하면 바로 아이템이 선택된 상태로 변경
 - 장비 세부정보 UI를 터치해야 UI가 꺼지도록 변경

#### 스타포스가 불가능한 아이템 판별
 - 기본적으로 업그레이드 가능 횟수가 존재하지 않으면 스타포스가 불가능함
 - 하지만 업그레이드 가능 횟수가 존재함에도 불구하고 스타포스가 불가능한 아이템을 아이템명으로 판별

#### Data Layer의 Entity와 Domain Layer의 Model 역할 구분
 - Data Layer의 Entity는 네트워크로 받아온 데이터를 담는 데 사용
 - Mapper를 통해 Domain Layer에 존재하는 Model로 데이터를 가공하고, 이 데이터를 UseCase가 Repository에 의존하여 사용

## 📝 To-Do
 - UI 바꾸는 거 말곤 할 건 없는듯

## ✅ Results
<p>
    <img width=250 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/cff917c2-dba5-48ef-8510-6a0466c1a998">
    <img width=250 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/0f440d8c-4445-4866-acc5-32fe42a08b0c">
    <img width=250 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/7dd70931-485c-4f98-8617-86c01a57e63c">
</p>

Close: #55 