### PR TITLE
[5/20] 캐릭터 스킬 데이터 가져오기

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.bodan.maplecalendar"
         minSdk = 28
         targetSdk = 34
-        versionCode = 25
-        versionName = "0.5.2"
+        versionCode = 26
+        versionName = "0.6.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/bodan/maplecalendar/data/api/MaplestoryApi.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/api/MaplestoryApi.kt
@@ -7,6 +7,7 @@ import com.bodan.maplecalendar.data.model.HyperStatEntity
 import com.bodan.maplecalendar.data.model.ItemEquipmentEntity
 import com.bodan.maplecalendar.data.model.OcidEntity
 import com.bodan.maplecalendar.data.model.PopularityEntity
+import com.bodan.maplecalendar.data.model.SkillEntity
 import com.bodan.maplecalendar.data.model.StatEntity
 import com.bodan.maplecalendar.data.model.UnionEntity
 import retrofit2.Response
@@ -67,4 +68,11 @@ interface MaplestoryApi {
         @Query("ocid") ocid: String,
         @Query("date") date: String?
     ): Response<AbilityEntity>
+
+    @GET("v1/character/skill")
+    suspend fun fetchCharacterSkill(
+        @Query("ocid") ocid: String,
+        @Query("date") date: String?,
+        @Query("character_skill_grade") characterSkillGrade: String
+    ): Response<SkillEntity>
 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/mapper/CharacterSkillMapper.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/mapper/CharacterSkillMapper.kt
@@ -1,0 +1,30 @@
+package com.bodan.maplecalendar.data.mapper
+
+import com.bodan.maplecalendar.data.model.SkillEntity
+import com.bodan.maplecalendar.domain.entity.CharacterSkill
+import com.bodan.maplecalendar.domain.entity.CharacterSkillInfo
+
+object CharacterSkillMapper {
+
+    operator fun invoke(skillEntity: SkillEntity): CharacterSkill {
+        val newCharacterSkills = mutableListOf<CharacterSkillInfo>()
+
+        skillEntity.characterSkill.forEach { skill ->
+            newCharacterSkills.add(
+                CharacterSkillInfo(
+                    skillName = skill.skillName,
+                    skillDescription = skill.skillDescription,
+                    skillLevel = skill.skillLevel.toString(),
+                    skillEffect = skill.skillEffect,
+                    skillIcon = skill.skillIcon
+                )
+            )
+        }
+
+        return CharacterSkill(
+            characterClass = skillEntity.characterClass,
+            characterSkillGrade = skillEntity.characterSkillGrade,
+            characterSkills = newCharacterSkills
+        )
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/data/model/MaplestoryEntity.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/model/MaplestoryEntity.kt
@@ -576,3 +576,35 @@ data class AbilityInfoEntity(
     @Json(name = "ability_value")
     val abilityValue: String
 )
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class SkillEntity(
+    @Json(name = "character_class")
+    val characterClass: String,
+
+    @Json(name = "character_skill_grade")
+    val characterSkillGrade: String,
+
+    @Json(name = "character_skill")
+    val characterSkill: List<SkillInfoEntity>
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class SkillInfoEntity(
+    @Json(name = "skill_name")
+    val skillName: String,
+
+    @Json(name = "skill_description")
+    val skillDescription: String,
+
+    @Json(name = "skill_level")
+    val skillLevel: Int,
+
+    @Json(name = "skill_effect")
+    val skillEffect: String,
+
+    @Json(name = "skill_icon")
+    val skillIcon: String
+)

--- a/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRemoteDataSource.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRemoteDataSource.kt
@@ -7,6 +7,7 @@ import com.bodan.maplecalendar.data.model.HyperStatEntity
 import com.bodan.maplecalendar.data.model.ItemEquipmentEntity
 import com.bodan.maplecalendar.data.model.OcidEntity
 import com.bodan.maplecalendar.data.model.PopularityEntity
+import com.bodan.maplecalendar.data.model.SkillEntity
 import com.bodan.maplecalendar.data.model.StatEntity
 import com.bodan.maplecalendar.data.model.UnionEntity
 import retrofit2.Response
@@ -19,7 +20,10 @@ interface MaplestoryRemoteDataSource {
 
     suspend fun getCharacterStat(ocid: String, date: String?): Response<StatEntity>
 
-    suspend fun getCharacterItemEquipment(ocid: String, date: String?): Response<ItemEquipmentEntity>
+    suspend fun getCharacterItemEquipment(
+        ocid: String,
+        date: String?
+    ): Response<ItemEquipmentEntity>
 
     suspend fun getCharacterUnion(ocid: String, date: String?): Response<UnionEntity>
 
@@ -30,4 +34,10 @@ interface MaplestoryRemoteDataSource {
     suspend fun getCharacterHyperStat(ocid: String, date: String?): Response<HyperStatEntity>
 
     suspend fun getCharacterAbility(ocid: String, date: String?): Response<AbilityEntity>
+
+    suspend fun getCharacterSkill(
+        ocid: String,
+        date: String?,
+        characterSkillGrade: String
+    ): Response<SkillEntity>
 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRemoteDataSourceImpl.kt
@@ -8,6 +8,7 @@ import com.bodan.maplecalendar.data.model.HyperStatEntity
 import com.bodan.maplecalendar.data.model.ItemEquipmentEntity
 import com.bodan.maplecalendar.data.model.OcidEntity
 import com.bodan.maplecalendar.data.model.PopularityEntity
+import com.bodan.maplecalendar.data.model.SkillEntity
 import com.bodan.maplecalendar.data.model.StatEntity
 import com.bodan.maplecalendar.data.model.UnionEntity
 import retrofit2.Response
@@ -29,8 +30,7 @@ class MaplestoryRemoteDataSourceImpl @Inject constructor(
     override suspend fun getCharacterItemEquipment(
         ocid: String,
         date: String?
-    ): Response<ItemEquipmentEntity> =
-        maplestoryApi.fetchCharacterItemEquipment(ocid, date)
+    ): Response<ItemEquipmentEntity> = maplestoryApi.fetchCharacterItemEquipment(ocid, date)
 
     override suspend fun getCharacterUnion(ocid: String, date: String?): Response<UnionEntity> =
         maplestoryApi.fetchCharacterUnion(ocid, date)
@@ -38,8 +38,7 @@ class MaplestoryRemoteDataSourceImpl @Inject constructor(
     override suspend fun getCharacterPopularity(
         ocid: String,
         date: String?
-    ): Response<PopularityEntity> =
-        maplestoryApi.fetchCharacterPopularity(ocid, date)
+    ): Response<PopularityEntity> = maplestoryApi.fetchCharacterPopularity(ocid, date)
 
     override suspend fun getCharacterDojang(ocid: String, date: String?): Response<DojangEntity> =
         maplestoryApi.fetchCharacterDojang(ocid, date)
@@ -47,9 +46,14 @@ class MaplestoryRemoteDataSourceImpl @Inject constructor(
     override suspend fun getCharacterHyperStat(
         ocid: String,
         date: String?
-    ): Response<HyperStatEntity> =
-        maplestoryApi.fetchCharacterHyperStat(ocid, date)
+    ): Response<HyperStatEntity> = maplestoryApi.fetchCharacterHyperStat(ocid, date)
 
     override suspend fun getCharacterAbility(ocid: String, date: String?): Response<AbilityEntity> =
         maplestoryApi.fetchCharacterAbility(ocid, date)
+
+    override suspend fun getCharacterSkill(
+        ocid: String,
+        date: String?,
+        characterSkillGrade: String
+    ): Response<SkillEntity> = maplestoryApi.fetchCharacterSkill(ocid, date, characterSkillGrade)
 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRepositoryImpl.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.bodan.maplecalendar.data.mapper.CharacterHyperStatMapper
 import com.bodan.maplecalendar.data.mapper.CharacterItemEquipmentMapper
 import com.bodan.maplecalendar.data.mapper.CharacterOcidMapper
 import com.bodan.maplecalendar.data.mapper.CharacterPopularityMapper
+import com.bodan.maplecalendar.data.mapper.CharacterSkillMapper
 import com.bodan.maplecalendar.data.mapper.CharacterStatMapper
 import com.bodan.maplecalendar.data.mapper.CharacterUnionMapper
 import com.bodan.maplecalendar.domain.entity.CharacterAbility
@@ -17,6 +18,7 @@ import com.bodan.maplecalendar.domain.entity.CharacterBasic
 import com.bodan.maplecalendar.domain.entity.CharacterHyperStat
 import com.bodan.maplecalendar.domain.entity.CharacterItemEquipment
 import com.bodan.maplecalendar.domain.entity.CharacterOcid
+import com.bodan.maplecalendar.domain.entity.CharacterSkill
 import com.bodan.maplecalendar.domain.entity.FinalStat
 import com.bodan.maplecalendar.domain.repository.MaplestoryRepository
 import com.bodan.maplecalendar.domain.entity.Result
@@ -176,6 +178,26 @@ class MaplestoryRepositoryImpl @Inject constructor(
             val body = response.body()
             if (response.isSuccessful && (body != null)) {
                 Result.success(CharacterAbilityMapper(body))
+            } else {
+                Result.error(response.errorBody().toString(), null)
+            }
+        } catch (e: Exception) {
+            Result.fail()
+        }
+
+    override suspend fun getCharacterSkill(
+        ocid: String,
+        date: String?,
+        characterSkillGrade: String
+    ): Result<CharacterSkill> =
+        try {
+            val response = withContext(CoroutineScope(Dispatchers.IO).coroutineContext) {
+                maplestoryRemoteDataSource.getCharacterSkill(ocid, date, characterSkillGrade)
+            }
+
+            val body = response.body()
+            if (response.isSuccessful && (body != null)) {
+                Result.success(CharacterSkillMapper(body))
             } else {
                 Result.error(response.errorBody().toString(), null)
             }

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterSkill.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterSkill.kt
@@ -1,0 +1,10 @@
+package com.bodan.maplecalendar.domain.entity
+
+import androidx.annotation.Keep
+
+@Keep
+data class CharacterSkill(
+    val characterClass: String,
+    val characterSkillGrade: String,
+    val characterSkills: List<CharacterSkillInfo>
+)

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterSkillInfo.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterSkillInfo.kt
@@ -1,0 +1,12 @@
+package com.bodan.maplecalendar.domain.entity
+
+import androidx.annotation.Keep
+
+@Keep
+data class CharacterSkillInfo(
+    val skillName: String,
+    val skillDescription: String,
+    val skillLevel: String,
+    val skillEffect: String,
+    val skillIcon: String
+)

--- a/app/src/main/java/com/bodan/maplecalendar/domain/repository/MaplestoryRepository.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/repository/MaplestoryRepository.kt
@@ -7,6 +7,7 @@ import com.bodan.maplecalendar.domain.entity.CharacterBasic
 import com.bodan.maplecalendar.domain.entity.CharacterHyperStat
 import com.bodan.maplecalendar.domain.entity.CharacterOcid
 import com.bodan.maplecalendar.domain.entity.CharacterPopularity
+import com.bodan.maplecalendar.domain.entity.CharacterSkill
 import com.bodan.maplecalendar.domain.entity.CharacterUnion
 import com.bodan.maplecalendar.domain.entity.FinalStat
 import com.bodan.maplecalendar.domain.entity.Result
@@ -19,7 +20,10 @@ interface MaplestoryRepository {
 
     suspend fun getCharacterPower(ocid: String, date: String?): Result<List<FinalStat>>
 
-    suspend fun getCharacterItemEquipment(ocid: String, date: String?): Result<CharacterItemEquipment>
+    suspend fun getCharacterItemEquipment(
+        ocid: String,
+        date: String?
+    ): Result<CharacterItemEquipment>
 
     suspend fun getCharacterUnion(ocid: String, date: String?): Result<CharacterUnion>
 
@@ -30,4 +34,10 @@ interface MaplestoryRepository {
     suspend fun getCharacterHyperStat(ocid: String, date: String?): Result<CharacterHyperStat>
 
     suspend fun getCharacterAbility(ocid: String, date: String?): Result<CharacterAbility>
+
+    suspend fun getCharacterSkill(
+        ocid: String,
+        date: String?,
+        characterSkillGrade: String
+    ): Result<CharacterSkill>
 }

--- a/app/src/main/java/com/bodan/maplecalendar/domain/usecase/GetCharacterSkillUseCase.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/usecase/GetCharacterSkillUseCase.kt
@@ -1,0 +1,19 @@
+package com.bodan.maplecalendar.domain.usecase
+
+import com.bodan.maplecalendar.domain.entity.CharacterSkill
+import com.bodan.maplecalendar.domain.entity.Result
+import com.bodan.maplecalendar.domain.repository.MaplestoryRepository
+import javax.inject.Inject
+
+class GetCharacterSkillUseCase @Inject constructor(
+    private val maplestoryRepository: MaplestoryRepository
+) {
+
+    suspend fun getCharacterSkill(
+        ocid: String,
+        date: String?,
+        characterSkillGrade: String
+    ): Result<CharacterSkill> {
+        return maplestoryRepository.getCharacterSkill(ocid, date, characterSkillGrade)
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/utils/SkillGenerator.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/utils/SkillGenerator.kt
@@ -1,0 +1,18 @@
+package com.bodan.maplecalendar.presentation.utils
+
+object SkillGenerator {
+
+    val skillGrades = listOf<String>(
+        "0",
+        "1",
+        "1.5",
+        "2",
+        "2.5",
+        "3",
+        "4",
+        "hyperpassive",
+        "hyperactive",
+        "5",
+        "6"
+    )
+}


### PR DESCRIPTION
# 2024. 05. 20
## 💭 Motivation
#### 캐릭터의 스킬 데이터를 가져오도록 하였다.

## 🔧 Changed
 - Data Layer에서 Api를 정의하고 Repository가 Api를 통해 데이터를 가져오고 Mapper로 데이터를 가공한다.
 - Domain Layer에서 Repository에 의존하는 UseCase가 스킬 데이터를 가져올 수 있도록 한다.
 - ViewModel은 해당 UseCase에 의존하고 UseCase를 통해 가져온 스킬 데이터를 관리한다.

## 📝 To-Do

## ✅ Results
<p>
    <img width=1355 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/07454af1-a5c9-45e6-a90c-e327ad21ac7f">
</p>