### PR TITLE
[5/28] 중복 클릭 방지

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.bodan.maplecalendar"
         minSdk = 28
         targetSdk = 34
-        versionCode = 28
-        versionName = "0.6.2"
+        versionCode = 29
+        versionName = "0.7.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/config/BaseDialogFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/config/BaseDialogFragment.kt
@@ -11,9 +11,13 @@ import android.view.ViewGroup
 import android.view.Window
 import android.view.WindowManager
 import android.widget.Toast
+import androidx.annotation.IdRes
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.DialogFragment
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import androidx.navigation.Navigator
 
 abstract class BaseDialogFragment<T : ViewDataBinding>(private val layoutId: Int) :
     DialogFragment() {
@@ -55,11 +59,7 @@ abstract class BaseDialogFragment<T : ViewDataBinding>(private val layoutId: Int
         _binding = null
     }
 
-    protected fun showToastMessage(message: String) {
-        Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show()
-    }
-
-    protected fun Context.dialogFragmentResize(
+    private fun Context.dialogFragmentResize(
         dialogFragment: DialogFragment,
         width: Float,
         height: Float
@@ -81,6 +81,23 @@ abstract class BaseDialogFragment<T : ViewDataBinding>(private val layoutId: Int
             val y = (rect.height() * height).toInt()
 
             window?.setLayout(x, y)
+        }
+    }
+
+    protected fun showToastMessage(message: String) {
+        Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show()
+    }
+
+    fun NavController.navigateSafely(
+        @IdRes actionId: Int,
+        args: Bundle? = null,
+        navOptions: NavOptions? = null,
+        navExtras: Navigator.Extras? = null
+    ) {
+        val action = currentDestination?.getAction(actionId) ?: graph.getAction(actionId)
+
+        if ((action != null) && (currentDestination?.id != action.destinationId)) {
+            navigate(actionId, args, navOptions, navExtras)
         }
     }
 }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/config/BaseFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/config/BaseFragment.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
+import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
@@ -14,6 +15,10 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
+import androidx.navigation.Navigator
+import androidx.navigation.get
 import com.bodan.maplecalendar.R
 import com.bodan.maplecalendar.app.MainApplication
 import com.google.android.material.snackbar.Snackbar
@@ -92,5 +97,18 @@ abstract class BaseFragment<T : ViewDataBinding>(private val layoutId: Int) : Fr
         }
 
         requireActivity().onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
+    }
+
+    fun NavController.navigateSafely(
+        @IdRes actionId: Int,
+        args: Bundle? = null,
+        navOptions: NavOptions? = null,
+        navExtras: Navigator.Extras? = null
+    ) {
+        val action = currentDestination?.getAction(actionId) ?: graph.getAction(actionId)
+
+        if ((action != null) && (currentDestination?.id != action.destinationId)) {
+            navigate(actionId, args, navOptions, navExtras)
+        }
     }
 }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/calendar/CalendarFragment.kt
@@ -58,7 +58,7 @@ class CalendarFragment : BaseFragment<FragmentCalendarBinding>(R.layout.fragment
         }
 
         is CalendarUiEvent.GetEventsOfDate -> {
-            findNavController().navigate(R.id.action_calendar_to_day_event)
+            findNavController().navigateSafely(R.id.action_calendar_to_day_event)
         }
 
         is CalendarUiEvent.SetDarkMode -> {

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/calendar/DayEventFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/calendar/DayEventFragment.kt
@@ -32,9 +32,12 @@ class DayEventFragment : BaseDialogFragment<FragmentDayEventBinding>(R.layout.fr
 
         lifecycleScope.launch {
             viewModel.calendarUiEvent.collectLatest { uiEvent ->
-                if (uiEvent == CalendarUiEvent.CloseEventsOfDate) dismiss()
-                if (uiEvent == CalendarUiEvent.StartEventUrl) {
-                    startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(viewModel.eventUrl.value)))
+                when (uiEvent) {
+                    is CalendarUiEvent.StartEventUrl -> getEventUrl()
+
+                    is CalendarUiEvent.CloseEventsOfDate -> dismiss()
+
+                    else -> {}
                 }
             }
         }
@@ -46,5 +49,14 @@ class DayEventFragment : BaseDialogFragment<FragmentDayEventBinding>(R.layout.fr
 
     private fun initRecyclerView() {
         binding.rvDayEvent.setHasFixedSize(false)
+    }
+
+    private fun getEventUrl() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(viewModel.eventUrl.value)).apply {
+            action = Intent.ACTION_MAIN
+            addCategory(Intent.CATEGORY_LAUNCHER)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+        startActivity(intent)
     }
 }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/character/CharacterFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/character/CharacterFragment.kt
@@ -71,11 +71,11 @@ class CharacterFragment : BaseFragment<FragmentCharacterBinding>(R.layout.fragme
         }
 
         is CharacterUiEvent.GetHyperStat -> {
-            findNavController().navigate(R.id.action_character_to_hyper_stat)
+            findNavController().navigateSafely(R.id.action_character_to_hyper_stat)
         }
 
         is CharacterUiEvent.GetAbility -> {
-            findNavController().navigate(R.id.action_character_to_ability)
+            findNavController().navigateSafely(R.id.action_character_to_ability)
         }
 
         else -> {}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentFragment.kt
@@ -42,7 +42,7 @@ class EquipmentFragment : BaseFragment<FragmentEquipmentBinding>(R.layout.fragme
         }
 
         is EquipmentUiEvent.GetItemEquipmentDetail -> {
-            findNavController().navigate(R.id.action_equipment_to_item_equipment_detail)
+            findNavController().navigateSafely(R.id.action_equipment_to_item_equipment_detail)
         }
 
         is EquipmentUiEvent.BadRequest -> {

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/lobby/LobbyFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/lobby/LobbyFragment.kt
@@ -53,7 +53,11 @@ class LobbyFragment : BaseFragment<FragmentLobbyBinding>(R.layout.fragment_lobby
 
     private fun handleUiEvent(event: LobbyUiEvent) = when (event) {
         is LobbyUiEvent.GoToCharacter -> {
-            val intent = Intent(requireContext(), CharacterActivity::class.java)
+            val intent = Intent(requireContext(), CharacterActivity::class.java).apply {
+                action = Intent.ACTION_MAIN
+                addCategory(Intent.CATEGORY_LAUNCHER)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
             startActivity(intent)
         }
 
@@ -82,7 +86,7 @@ class LobbyFragment : BaseFragment<FragmentLobbyBinding>(R.layout.fragment_lobby
         }
 
         is LobbyUiEvent.SelectSearchDate -> {
-            findNavController().navigate(R.id.action_lobby_to_search_date)
+            findNavController().navigateSafely(R.id.action_lobby_to_search_date)
         }
 
         is LobbyUiEvent.StartEventUrl -> {

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/setting/SettingFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/setting/SettingFragment.kt
@@ -44,11 +44,11 @@ class SettingFragment : BaseFragment<FragmentSettingBinding>(R.layout.fragment_s
         }
 
         is SettingUiEvent.ChangeCharacterName -> {
-            findNavController().navigate(R.id.action_setting_to_change_character_name)
+            findNavController().navigateSafely(R.id.action_setting_to_change_character_name)
         }
 
         is SettingUiEvent.SetPushNotification -> {
-            findNavController().navigate(R.id.action_setting_to_push_notification)
+            findNavController().navigateSafely(R.id.action_setting_to_push_notification)
         }
 
         is SettingUiEvent.SetDarkMode -> {

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/SkillFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/SkillFragment.kt
@@ -68,15 +68,15 @@ class SkillFragment : BaseFragment<FragmentSkillBinding>(R.layout.fragment_skill
 
     private fun handleUiEvent(event: SkillUiEvent) = when (event) {
         is SkillUiEvent.GetSkillDetail -> {
-            findNavController().navigate(R.id.action_skill_to_skill_detail)
+            findNavController().navigateSafely(R.id.action_skill_to_skill_detail)
         }
 
         is SkillUiEvent.GetHyperSkill -> {
-            findNavController().navigate(R.id.action_skill_to_hyper_skill)
+            findNavController().navigateSafely(R.id.action_skill_to_hyper_skill)
         }
 
         is SkillUiEvent.GetLinkSkill -> {
-            findNavController().navigate(R.id.action_skill_to_link_skill)
+            findNavController().navigateSafely(R.id.action_skill_to_link_skill)
         }
 
         is SkillUiEvent.BadRequest -> {

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/hyperskill/HyperSkillAdapter.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/hyperskill/HyperSkillAdapter.kt
@@ -1,22 +1,22 @@
-package com.bodan.maplecalendar.presentation.views.skill
+package com.bodan.maplecalendar.presentation.views.skill.hyperskill
 
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
 
-class LinkSkillAdapter(fm: FragmentActivity, private val size: Int) : FragmentStateAdapter(fm) {
+class HyperSkillAdapter(fm: FragmentActivity, private val size: Int) : FragmentStateAdapter(fm) {
 
     override fun getItemCount(): Int = size
 
     override fun createFragment(position: Int): Fragment {
         val itemId = getItemId(position)
 
-        return LinkSkillInfoFragment.newInstance(itemId)
+        return HyperSkillInfoFragment.newInstance(itemId)
     }
 
     override fun getItemId(position: Int): Long = (position - START_POSITION).toLong()
 
-    override fun containsItem(itemId: Long): Boolean = ((itemId >= 0) && (itemId < size))
+    override fun containsItem(itemId: Long): Boolean = ((itemId >= START_POSITION) && (itemId < size))
 
     companion object {
         const val START_POSITION = 0

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/hyperskill/HyperSkillFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/hyperskill/HyperSkillFragment.kt
@@ -1,4 +1,4 @@
-package com.bodan.maplecalendar.presentation.views.skill
+package com.bodan.maplecalendar.presentation.views.skill.hyperskill
 
 import android.os.Bundle
 import android.view.View
@@ -9,6 +9,7 @@ import com.bodan.maplecalendar.R
 import com.bodan.maplecalendar.databinding.FragmentHyperSkillBinding
 import com.bodan.maplecalendar.presentation.config.BaseDialogFragment
 import com.bodan.maplecalendar.presentation.views.CharacterViewModel
+import com.bodan.maplecalendar.presentation.views.skill.SkillUiEvent
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -32,7 +33,7 @@ class HyperSkillFragment :
             viewModel.skillUiEvent.collectLatest { uiEvent ->
                 when (uiEvent) {
                     is SkillUiEvent.GetHyperSkillDetail -> {
-                        findNavController().navigate(R.id.action_hyper_skill_to_skill_detail)
+                        findNavController().navigateSafely(R.id.action_hyper_skill_to_skill_detail)
                     }
 
                     is SkillUiEvent.CloseHyperSkill -> dismiss()

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/hyperskill/HyperSkillInfoAdapter.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/hyperskill/HyperSkillInfoAdapter.kt
@@ -1,10 +1,11 @@
-package com.bodan.maplecalendar.presentation.views.skill
+package com.bodan.maplecalendar.presentation.views.skill.hyperskill
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.bodan.maplecalendar.databinding.ItemHyperSkillInfoBinding
 import com.bodan.maplecalendar.domain.entity.CharacterSkillInfo
+import com.bodan.maplecalendar.presentation.views.skill.OnSkillClickListener
 
 class HyperSkillInfoAdapter(
     private val hyperSkillInfos: List<CharacterSkillInfo>,

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/hyperskill/HyperSkillInfoFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/hyperskill/HyperSkillInfoFragment.kt
@@ -1,4 +1,4 @@
-package com.bodan.maplecalendar.presentation.views.skill
+package com.bodan.maplecalendar.presentation.views.skill.hyperskill
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/linkskill/LinkSkillAdapter.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/linkskill/LinkSkillAdapter.kt
@@ -1,22 +1,22 @@
-package com.bodan.maplecalendar.presentation.views.skill
+package com.bodan.maplecalendar.presentation.views.skill.linkskill
 
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
 
-class HyperSkillAdapter(fm: FragmentActivity, private val size: Int) : FragmentStateAdapter(fm) {
+class LinkSkillAdapter(fm: FragmentActivity, private val size: Int) : FragmentStateAdapter(fm) {
 
     override fun getItemCount(): Int = size
 
     override fun createFragment(position: Int): Fragment {
         val itemId = getItemId(position)
 
-        return HyperSkillInfoFragment.newInstance(itemId)
+        return LinkSkillInfoFragment.newInstance(itemId)
     }
 
     override fun getItemId(position: Int): Long = (position - START_POSITION).toLong()
 
-    override fun containsItem(itemId: Long): Boolean = ((itemId >= START_POSITION) && (itemId < size))
+    override fun containsItem(itemId: Long): Boolean = ((itemId >= 0) && (itemId < size))
 
     companion object {
         const val START_POSITION = 0

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/linkskill/LinkSkillFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/linkskill/LinkSkillFragment.kt
@@ -1,4 +1,4 @@
-package com.bodan.maplecalendar.presentation.views.skill
+package com.bodan.maplecalendar.presentation.views.skill.linkskill
 
 import android.os.Bundle
 import android.view.View
@@ -9,6 +9,7 @@ import com.bodan.maplecalendar.R
 import com.bodan.maplecalendar.databinding.FragmentLinkSkillBinding
 import com.bodan.maplecalendar.presentation.config.BaseDialogFragment
 import com.bodan.maplecalendar.presentation.views.CharacterViewModel
+import com.bodan.maplecalendar.presentation.views.skill.SkillUiEvent
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -32,7 +33,7 @@ class LinkSkillFragment :
             viewModel.skillUiEvent.collectLatest { uiEvent ->
                 when (uiEvent) {
                     is SkillUiEvent.GetLinkSkillDetail -> {
-                        findNavController().navigate(R.id.action_link_skill_to_skill_detail)
+                        findNavController().navigateSafely(R.id.action_link_skill_to_skill_detail)
                     }
 
                     is SkillUiEvent.CloseLinkSkill -> dismiss()

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/linkskill/LinkSkillInfoAdapter.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/linkskill/LinkSkillInfoAdapter.kt
@@ -1,10 +1,11 @@
-package com.bodan.maplecalendar.presentation.views.skill
+package com.bodan.maplecalendar.presentation.views.skill.linkskill
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.bodan.maplecalendar.databinding.ItemLinkSkillInfoBinding
 import com.bodan.maplecalendar.domain.entity.CharacterSkillInfo
+import com.bodan.maplecalendar.presentation.views.skill.OnSkillClickListener
 
 class LinkSkillInfoAdapter(
     private val linkSkills: List<CharacterSkillInfo>,

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/linkskill/LinkSkillInfoFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/skill/linkskill/LinkSkillInfoFragment.kt
@@ -1,4 +1,4 @@
-package com.bodan.maplecalendar.presentation.views.skill
+package com.bodan.maplecalendar.presentation.views.skill.linkskill
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment

--- a/app/src/main/res/layout/fragment_hyper_skill_info.xml
+++ b/app/src/main/res/layout/fragment_hyper_skill_info.xml
@@ -18,7 +18,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            tools:context=".presentation.views.skill.HyperSkillInfoFragment">
+            tools:context=".presentation.views.skill.hyperskill.HyperSkillInfoFragment">
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_hyper_skill_info"

--- a/app/src/main/res/layout/fragment_link_skill.xml
+++ b/app/src/main/res/layout/fragment_link_skill.xml
@@ -19,7 +19,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@drawable/shape_equipment"
-            tools:context=".presentation.views.skill.LinkSkillFragment">
+            tools:context=".presentation.views.skill.linkskill.LinkSkillFragment">
 
             <androidx.constraintlayout.widget.Guideline
                 android:id="@+id/gl_left_link_skill"

--- a/app/src/main/res/layout/fragment_link_skill_info.xml
+++ b/app/src/main/res/layout/fragment_link_skill_info.xml
@@ -18,7 +18,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            tools:context=".presentation.views.skill.LinkSkillInfoFragment">
+            tools:context=".presentation.views.skill.linkskill.LinkSkillInfoFragment">
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_link_skill_info"

--- a/app/src/main/res/navigation/nav_graph_character.xml
+++ b/app/src/main/res/navigation/nav_graph_character.xml
@@ -75,7 +75,7 @@
 
     <dialog
         android:id="@+id/fragment_hyper_skill"
-        android:name="com.bodan.maplecalendar.presentation.views.skill.HyperSkillFragment"
+        android:name="com.bodan.maplecalendar.presentation.views.skill.hyperskill.HyperSkillFragment"
         android:label="@string/name_hyper_skill">
 
         <action
@@ -86,7 +86,7 @@
 
     <dialog
         android:id="@+id/fragment_link_skill"
-        android:name="com.bodan.maplecalendar.presentation.views.skill.LinkSkillFragment"
+        android:name="com.bodan.maplecalendar.presentation.views.skill.linkskill.LinkSkillFragment"
         android:label="@string/name_link_skill">
 
         <action


### PR DESCRIPTION
# 2024. 05. 28
## 💭 Motivation
#### 중복 클릭 시 팅기는 현상을 방지하고자 하였다.

## 🔧 Changed
 - Activity & Fragment -> Activity : intent의 action을 ACTION_MAIN으로 설정, 카테고리 추가 후 flag를 NEW_TASK로 설정하면 중복 클릭해도 하나의 Activity만 나타남
 - Fragment -> DialogFragment : 확장 함수를 선언하여, Fragment 간 이동 action이 존재하면서 현재 Fragment와 destination의 id를 비교하여 다를 경우에만 이동함으로써 중복 클릭 시 발생하는 Navigation Id 오류를 방지
 - 상태를 활용한 중복 클릭 방지(특정 날짜의 이벤트 리스트를 보기 위해 특정 날짜를 터치하면 먼저 해당 날짜를 저장, 이후 날짜가 빈 문자열이 아니면 이벤트 리스트를 불러오고 Dialog로 보여주도록 동작, Dialog가 종료되면 다시 저장한 날짜 데이터를 초기화함)

## 📝 To-Do
 - Retrofit API Response 응답 코드에 따른 핸들링

## ✅ Results
없음