### PR TITLE
[5/29] DataStore 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.bodan.maplecalendar"
         minSdk = 28
         targetSdk = 34
-        versionCode = 29
-        versionName = "0.7.0"
+        versionCode = 30
+        versionName = "0.7.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -83,6 +83,9 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+
+    // Preferences DataStore
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
 
     // Firebase
     implementation(platform("com.google.firebase:firebase-bom:32.7.0"))

--- a/app/src/main/java/com/bodan/maplecalendar/app/MainApplication.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/app/MainApplication.kt
@@ -2,8 +2,6 @@ package com.bodan.maplecalendar.app
 
 import android.app.Application
 import android.content.Context
-import androidx.appcompat.app.AppCompatDelegate
-import com.bodan.maplecalendar.R
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 
@@ -15,20 +13,9 @@ class MainApplication : Application() {
     }
 
     override fun onCreate() {
-        mySharedPreferences = MySharedPreferences()
         super.onCreate()
 
-        when (mySharedPreferences.getThemeMode("theme", "")) {
-            myContext().getString(R.string.text_light_mode) -> {
-                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
-            }
-
-            myContext().getString(R.string.text_dark_mode) -> {
-                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
-            }
-
-            else -> {}
-        }
+        mySharedPreferences = MySharedPreferences()
 
         Timber.plant(Timber.DebugTree())
     }

--- a/app/src/main/java/com/bodan/maplecalendar/app/MySharedPreferences.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/app/MySharedPreferences.kt
@@ -2,18 +2,11 @@ package com.bodan.maplecalendar.app
 
 import android.content.Context
 import android.content.SharedPreferences
-import com.bodan.maplecalendar.R
 
 class MySharedPreferences {
 
     private val preferences: SharedPreferences =
         MainApplication.myContext().getSharedPreferences("prefs_name", Context.MODE_PRIVATE)
-
-    init {
-        if (getThemeMode("theme", "") == "") {
-            setThemeMode("theme", MainApplication.myContext().getString(R.string.text_light_mode))
-        }
-    }
 
     fun getSearchDate(key: String, defValue: String?): String? {
         return preferences.getString(key, defValue)
@@ -36,14 +29,6 @@ class MySharedPreferences {
     }
 
     fun setOcid(key: String, defValue: String) {
-        preferences.edit().putString(key, defValue).apply()
-    }
-
-    fun getThemeMode(key: String, defValue: String): String {
-        return preferences.getString(key, defValue).toString()
-    }
-
-    fun setThemeMode(key: String, defValue: String) {
         preferences.edit().putString(key, defValue).apply()
     }
 

--- a/app/src/main/java/com/bodan/maplecalendar/data/di/PersistenceModule.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/di/PersistenceModule.kt
@@ -1,0 +1,31 @@
+package com.bodan.maplecalendar.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+
+@InstallIn(SingletonComponent::class)
+@Module
+object PersistenceModule {
+
+    private const val DATA_STORE_NAME = "data_store"
+
+    @Provides
+    @Singleton
+    fun providePreferencesDataStore(@ApplicationContext context: Context): DataStore<Preferences> {
+        return PreferenceDataStoreFactory.create(
+            produceFile = {
+                context.preferencesDataStoreFile(DATA_STORE_NAME)
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/data/di/RepositoryModule.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/di/RepositoryModule.kt
@@ -1,8 +1,12 @@
 package com.bodan.maplecalendar.data.di
 
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import com.bodan.maplecalendar.data.repository.MaplestoryRemoteDataSource
 import com.bodan.maplecalendar.data.repository.MaplestoryRepositoryImpl
+import com.bodan.maplecalendar.data.repository.SettingsRepositoryImpl
 import com.bodan.maplecalendar.domain.repository.MaplestoryRepository
+import com.bodan.maplecalendar.domain.repository.SettingsRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -17,5 +21,11 @@ class RepositoryModule {
     @Singleton
     fun provideMaplestoryRepository(maplestoryRemoteDataSource: MaplestoryRemoteDataSource): MaplestoryRepository {
         return MaplestoryRepositoryImpl(maplestoryRemoteDataSource)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSettingsRepository(dataStore: DataStore<Preferences>): SettingsRepository {
+        return SettingsRepositoryImpl(dataStore)
     }
 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/repository/SettingsRepositoryImpl.kt
@@ -1,0 +1,47 @@
+package com.bodan.maplecalendar.data.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import com.bodan.maplecalendar.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class SettingsRepositoryImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) : SettingsRepository {
+
+    override suspend fun setDarkMode() {
+        dataStore.edit { preferences ->
+            preferences[DARK_MODE] = when (preferences[DARK_MODE]) {
+                true -> false
+
+                false -> true
+
+                else -> false
+            }
+        }
+    }
+
+    override fun getDarkMode(): Flow<Boolean> {
+        return dataStore.data.catch {
+            if (it is IOException) {
+                it.printStackTrace()
+                emit(emptyPreferences())
+            } else {
+                throw it
+            }
+        }.map { preferences ->
+            preferences[DARK_MODE] ?: false
+        }
+    }
+
+    companion object {
+        private val DARK_MODE = booleanPreferencesKey("dark_mode")
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/repository/SettingsRepository.kt
@@ -1,0 +1,10 @@
+package com.bodan.maplecalendar.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface SettingsRepository {
+
+    suspend fun setDarkMode()
+
+    fun getDarkMode(): Flow<Boolean>
+}

--- a/app/src/main/java/com/bodan/maplecalendar/domain/usecase/SetDarkModeUseCase.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/usecase/SetDarkModeUseCase.kt
@@ -1,0 +1,18 @@
+package com.bodan.maplecalendar.domain.usecase
+
+import com.bodan.maplecalendar.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SetDarkModeUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository
+) {
+
+    suspend fun setDarkMode() {
+        settingsRepository.setDarkMode()
+    }
+
+    fun getDarkMode(): Flow<Boolean> {
+        return settingsRepository.getDarkMode()
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/config/BaseFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/config/BaseFragment.kt
@@ -18,9 +18,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 import androidx.navigation.Navigator
-import androidx.navigation.get
-import com.bodan.maplecalendar.R
-import com.bodan.maplecalendar.app.MainApplication
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
@@ -55,15 +52,13 @@ abstract class BaseFragment<T : ViewDataBinding>(private val layoutId: Int) : Fr
         _binding = null
     }
 
-    protected fun setDarkMode() {
-        when (MainApplication.mySharedPreferences.getThemeMode("theme", "")) {
-            getString(R.string.text_light_mode) -> {
-                MainApplication.mySharedPreferences.setThemeMode("theme", getString(R.string.text_dark_mode))
+    protected fun setDarkMode(isDarkMode: Boolean?) {
+        when (isDarkMode) {
+            true -> {
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
             }
 
-            getString(R.string.text_dark_mode) -> {
-                MainApplication.mySharedPreferences.setThemeMode("theme", getString(R.string.text_light_mode))
+            false -> {
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
             }
 

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/calendar/CalendarFragment.kt
@@ -3,12 +3,15 @@ package com.bodan.maplecalendar.presentation.views.calendar
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.bodan.maplecalendar.R
 import com.bodan.maplecalendar.databinding.FragmentCalendarBinding
 import com.bodan.maplecalendar.presentation.config.BaseFragment
 import com.bodan.maplecalendar.presentation.views.MainViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class CalendarFragment : BaseFragment<FragmentCalendarBinding>(R.layout.fragment_calendar) {
@@ -21,6 +24,7 @@ class CalendarFragment : BaseFragment<FragmentCalendarBinding>(R.layout.fragment
 
         initListAdapter()
         initRecyclerView()
+        collectDarkMode()
 
         binding.vm = viewModel
         binding.listAdapter = calendarListAdapter
@@ -34,6 +38,14 @@ class CalendarFragment : BaseFragment<FragmentCalendarBinding>(R.layout.fragment
 
     private fun initRecyclerView() {
         binding.rvCalendar.setHasFixedSize(false)
+    }
+
+    private fun collectDarkMode() {
+        lifecycleScope.launch {
+            viewModel.getDarkMode().collectLatest { isDarkMode ->
+                setDarkMode(isDarkMode)
+            }
+        }
     }
 
     private fun handleUiEvent(event: CalendarUiEvent) = when (event) {
@@ -61,8 +73,8 @@ class CalendarFragment : BaseFragment<FragmentCalendarBinding>(R.layout.fragment
             findNavController().navigateSafely(R.id.action_calendar_to_day_event)
         }
 
-        is CalendarUiEvent.SetDarkMode -> {
-            setDarkMode()
+        is CalendarUiEvent.GetDarkMode -> {
+            setDarkMode(event.isDarkMode)
         }
 
         else -> {}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/calendar/CalendarUiEvent.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/calendar/CalendarUiEvent.kt
@@ -2,6 +2,14 @@ package com.bodan.maplecalendar.presentation.views.calendar
 
 sealed class CalendarUiEvent {
 
+    data object GetEventsOfDate : CalendarUiEvent()
+
+    data object CloseEventsOfDate : CalendarUiEvent()
+
+    data object StartEventUrl : CalendarUiEvent()
+
+    data class GetDarkMode(val isDarkMode: Boolean?) : CalendarUiEvent()
+
     data object BadRequest : CalendarUiEvent()
 
     data object UnauthorizedStatus : CalendarUiEvent()
@@ -11,12 +19,4 @@ sealed class CalendarUiEvent {
     data object TooManyRequests : CalendarUiEvent()
 
     data object InternalServerError : CalendarUiEvent()
-
-    data object GetEventsOfDate : CalendarUiEvent()
-
-    data object CloseEventsOfDate : CalendarUiEvent()
-
-    data object StartEventUrl : CalendarUiEvent()
-
-    data object SetDarkMode : CalendarUiEvent()
 }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/calendar/DayEventFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/calendar/DayEventFragment.kt
@@ -52,11 +52,7 @@ class DayEventFragment : BaseDialogFragment<FragmentDayEventBinding>(R.layout.fr
     }
 
     private fun getEventUrl() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(viewModel.eventUrl.value)).apply {
-            action = Intent.ACTION_MAIN
-            addCategory(Intent.CATEGORY_LAUNCHER)
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        }
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(viewModel.eventUrl.value))
         startActivity(intent)
     }
 }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/character/CharacterFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/character/CharacterFragment.kt
@@ -66,8 +66,8 @@ class CharacterFragment : BaseFragment<FragmentCharacterBinding>(R.layout.fragme
             showSnackBar(R.string.message_network_error)
         }
 
-        is CharacterUiEvent.SetDarkMode -> {
-            setDarkMode()
+        is CharacterUiEvent.GetDarkMode -> {
+            setDarkMode(event.isDarkMode)
         }
 
         is CharacterUiEvent.GetHyperStat -> {

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/character/CharacterUiEvent.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/character/CharacterUiEvent.kt
@@ -10,6 +10,8 @@ sealed class CharacterUiEvent {
 
     data object CloseAbility : CharacterUiEvent()
 
+    data class GetDarkMode(val isDarkMode: Boolean?) : CharacterUiEvent()
+
     data object BadRequest : CharacterUiEvent()
 
     data object UnauthorizedStatus : CharacterUiEvent()
@@ -19,6 +21,4 @@ sealed class CharacterUiEvent {
     data object TooManyRequests : CharacterUiEvent()
 
     data object InternalServerError : CharacterUiEvent()
-
-    data object SetDarkMode : CharacterUiEvent()
 }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentFragment.kt
@@ -65,8 +65,8 @@ class EquipmentFragment : BaseFragment<FragmentEquipmentBinding>(R.layout.fragme
             showSnackBar(R.string.message_network_error)
         }
 
-        is EquipmentUiEvent.SetDarkMode -> {
-            setDarkMode()
+        is EquipmentUiEvent.GetDarkMode -> {
+            setDarkMode(event.isDarkMode)
         }
 
         else -> {}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentUiEvent.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentUiEvent.kt
@@ -8,6 +8,8 @@ sealed class EquipmentUiEvent {
 
     data object CloseItemEquipmentDetail : EquipmentUiEvent()
 
+    data class GetDarkMode(val isDarkMode: Boolean?) : EquipmentUiEvent()
+
     data object BadRequest : EquipmentUiEvent()
 
     data object UnauthorizedStatus : EquipmentUiEvent()
@@ -17,6 +19,4 @@ sealed class EquipmentUiEvent {
     data object TooManyRequests : EquipmentUiEvent()
 
     data object InternalServerError : EquipmentUiEvent()
-
-    data object SetDarkMode : EquipmentUiEvent()
 }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/lobby/LobbyFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/lobby/LobbyFragment.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.bodan.maplecalendar.R
 import com.bodan.maplecalendar.databinding.FragmentLobbyBinding
@@ -12,6 +13,8 @@ import com.bodan.maplecalendar.presentation.config.BaseFragment
 import com.bodan.maplecalendar.presentation.views.CharacterActivity
 import com.bodan.maplecalendar.presentation.views.MainViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class LobbyFragment : BaseFragment<FragmentLobbyBinding>(R.layout.fragment_lobby) {
@@ -24,6 +27,7 @@ class LobbyFragment : BaseFragment<FragmentLobbyBinding>(R.layout.fragment_lobby
 
         initListAdapter()
         initRecyclerView()
+        collectDarkMode()
 
         binding.vm = viewModel
         binding.listAdapter = eventListAdapter
@@ -39,6 +43,14 @@ class LobbyFragment : BaseFragment<FragmentLobbyBinding>(R.layout.fragment_lobby
 
     private fun initRecyclerView() {
         binding.rvLobby.setHasFixedSize(false)
+    }
+
+    private fun collectDarkMode() {
+        lifecycleScope.launch {
+            viewModel.getDarkMode().collectLatest { isDarkMode ->
+                setDarkMode(isDarkMode)
+            }
+        }
     }
 
     private fun setSwipeRefresh() {
@@ -81,8 +93,8 @@ class LobbyFragment : BaseFragment<FragmentLobbyBinding>(R.layout.fragment_lobby
             showSnackBar(R.string.message_network_error)
         }
 
-        is LobbyUiEvent.SetDarkMode -> {
-            setDarkMode()
+        is LobbyUiEvent.GetDarkMode -> {
+            setDarkMode(event.isDarkMode)
         }
 
         is LobbyUiEvent.SelectSearchDate -> {

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/lobby/LobbyUiEvent.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/lobby/LobbyUiEvent.kt
@@ -4,6 +4,14 @@ sealed class LobbyUiEvent {
 
     data object GoToCharacter : LobbyUiEvent()
 
+    data object SelectSearchDate : LobbyUiEvent()
+
+    data object CloseSearchDate : LobbyUiEvent()
+
+    data object StartEventUrl : LobbyUiEvent()
+
+    data class GetDarkMode(val isDarkMode: Boolean?) : LobbyUiEvent()
+
     data object BadRequest : LobbyUiEvent()
 
     data object UnauthorizedStatus : LobbyUiEvent()
@@ -13,12 +21,4 @@ sealed class LobbyUiEvent {
     data object TooManyRequests : LobbyUiEvent()
 
     data object InternalServerError : LobbyUiEvent()
-
-    data object SelectSearchDate : LobbyUiEvent()
-
-    data object CloseSearchDate : LobbyUiEvent()
-
-    data object StartEventUrl : LobbyUiEvent()
-
-    data object SetDarkMode : LobbyUiEvent()
 }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/setting/SettingFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/setting/SettingFragment.kt
@@ -3,12 +3,15 @@ package com.bodan.maplecalendar.presentation.views.setting
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.bodan.maplecalendar.R
 import com.bodan.maplecalendar.databinding.FragmentSettingBinding
 import com.bodan.maplecalendar.presentation.config.BaseFragment
 import com.bodan.maplecalendar.presentation.views.MainViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class SettingFragment : BaseFragment<FragmentSettingBinding>(R.layout.fragment_setting) {
@@ -17,9 +20,20 @@ class SettingFragment : BaseFragment<FragmentSettingBinding>(R.layout.fragment_s
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        collectDarkMode()
+
         binding.vm = viewModel
 
         collectLatestFlow(viewModel.settingUiEvent) { handleUiEvent(it) }
+    }
+
+    private fun collectDarkMode() {
+        lifecycleScope.launch {
+            viewModel.getDarkMode().collectLatest { isDarkMode ->
+                setDarkMode(isDarkMode)
+            }
+        }
     }
 
     private fun handleUiEvent(event: SettingUiEvent) = when (event) {
@@ -51,8 +65,8 @@ class SettingFragment : BaseFragment<FragmentSettingBinding>(R.layout.fragment_s
             findNavController().navigateSafely(R.id.action_setting_to_push_notification)
         }
 
-        is SettingUiEvent.SetDarkMode -> {
-            setDarkMode()
+        is SettingUiEvent.GetDarkMode -> {
+            setDarkMode(event.isDarkMode)
         }
 
         else -> {}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/setting/SettingUiEvent.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/setting/SettingUiEvent.kt
@@ -2,16 +2,6 @@ package com.bodan.maplecalendar.presentation.views.setting
 
 sealed class SettingUiEvent {
 
-    data object BadRequest : SettingUiEvent()
-
-    data object UnauthorizedStatus : SettingUiEvent()
-
-    data object Forbidden : SettingUiEvent()
-
-    data object TooManyRequests : SettingUiEvent()
-
-    data object InternalServerError : SettingUiEvent()
-
     data object ChangeCharacterName : SettingUiEvent()
 
     data object CloseChangeCharacterName : SettingUiEvent()
@@ -24,5 +14,15 @@ sealed class SettingUiEvent {
 
     data object ClosePushNotification : SettingUiEvent()
 
-    data object SetDarkMode : SettingUiEvent()
+    data class GetDarkMode(val isDarkMode: Boolean?) : SettingUiEvent()
+
+    data object BadRequest : SettingUiEvent()
+
+    data object UnauthorizedStatus : SettingUiEvent()
+
+    data object Forbidden : SettingUiEvent()
+
+    data object TooManyRequests : SettingUiEvent()
+
+    data object InternalServerError : SettingUiEvent()
 }


### PR DESCRIPTION
# 2024. 05. 29
## 💭 Motivation
#### ocid와 캐릭터 닉네임을 로컬에 저장하는데 ocid를 비동기로 받아오기 때문에 UI Thread를 블로킹할 수 있는 SharedPreferences 대신 DataStore를 사용하기로 하였다.

## 🔧 Changed
#### DataStore로 다크모드 데이터 관리
 - Data Layer에서 DataStoreFactory를 통해 Singleton으로 DataStore 생성
 - Domain Layer에서 해당 DataStore에 의존하는 Repository 선언
 - Data Layer에서 해당 Repository를 정의하여 다크모드를 설정하는 메소드와 다크모드 여부를 나타내는 변수를 return하는 메소드 정의
 - Domain Layer에서 해당 Repository에 의존하는 UseCase를 정의
 - UI Layer에서 UseCase에 ViewModel이 의존하도록 하고 UseCase를 통해 다크모드를 설정하는 메소드와 다크모드 변수를 return하는 메소드를 선언
 - 이렇게 DataStore를 앱이 실행 중인 동안 Singleton으로 사용하면서 데이터를 로컬에 저장할 수 있게 되었음
 - 다크모드로 종료한 후 다시 앱을 켜도 다크모드를 유지하기 위해 Fragment는 ViewModel에 존재하는 getDarkMode()가 emit하는 데이터를 collect하여 다크모드의 설정 여부를 결정함

## 📝 To-Do
 - 이제 캐릭터 닉네임, 캐릭터 조회 날짜, 캐릭터 ocid를 저장해야 한다.