### PR TITLE
[5/30] DataStore로 캐릭터 닉네임, ocid, 조회 날짜 관리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.bodan.maplecalendar"
         minSdk = 28
         targetSdk = 34
-        versionCode = 30
-        versionName = "0.7.1"
+        versionCode = 32
+        versionName = "0.7.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/bodan/maplecalendar/app/MySharedPreferences.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/app/MySharedPreferences.kt
@@ -8,30 +8,6 @@ class MySharedPreferences {
     private val preferences: SharedPreferences =
         MainApplication.myContext().getSharedPreferences("prefs_name", Context.MODE_PRIVATE)
 
-    fun getSearchDate(key: String, defValue: String?): String? {
-        return preferences.getString(key, defValue)
-    }
-
-    fun setSearchDate(key: String, defValue: String?) {
-        preferences.edit().putString(key, defValue).apply()
-    }
-
-    fun getNickname(key: String, defValue: String): String {
-        return preferences.getString(key, defValue).toString()
-    }
-
-    fun setNickname(key: String, defValue: String) {
-        preferences.edit().putString(key, defValue).apply()
-    }
-
-    fun getOcid(key: String, defValue: String): String {
-        return preferences.getString(key, defValue).toString()
-    }
-
-    fun setOcid(key: String, defValue: String) {
-        preferences.edit().putString(key, defValue).apply()
-    }
-
     fun getAlarm(key: String, defValue: String): String {
         return preferences.getString(key, defValue).toString()
     }

--- a/app/src/main/java/com/bodan/maplecalendar/data/mapper/CharacterBasicMapper.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/mapper/CharacterBasicMapper.kt
@@ -7,7 +7,7 @@ object CharacterBasicMapper {
 
     operator fun invoke(basicEntity: BasicEntity): CharacterBasic =
         CharacterBasic(
-            characterLevel = basicEntity.characterLevel,
+            characterLevel = basicEntity.characterLevel.toString(),
             characterClass = basicEntity.characterClass,
             worldName = basicEntity.worldName,
             characterGuildName = basicEntity.characterGuildName,

--- a/app/src/main/java/com/bodan/maplecalendar/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/repository/SettingsRepositoryImpl.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
 import com.bodan.maplecalendar.domain.repository.SettingsRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -41,7 +42,71 @@ class SettingsRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun setCharacterName(characterName: String) {
+        dataStore.edit { preferences ->
+            preferences[CHARACTER_NAME] = characterName
+        }
+    }
+
+    override fun getCharacterName(): Flow<String> {
+        return dataStore.data.catch {
+            if (it is IOException) {
+                it.printStackTrace()
+                emit(emptyPreferences())
+            } else {
+                throw it
+            }
+        }.map { preferences ->
+            preferences[CHARACTER_NAME] ?: "한달해"
+        }
+    }
+
+    override suspend fun setCharacterOcid(characterOcid: String) {
+        dataStore.edit { preferences ->
+            preferences[CHARACTER_OCID] = characterOcid
+        }
+    }
+
+    override fun getCharacterOcid(): Flow<String> {
+        return dataStore.data.catch {
+            if (it is IOException) {
+                it.printStackTrace()
+                emit(emptyPreferences())
+            } else {
+                throw it
+            }
+        }.map { preferences ->
+            preferences[CHARACTER_OCID] ?: ""
+        }
+    }
+
+    override suspend fun setSearchDate(searchDate: String?) {
+        dataStore.edit { preferences ->
+            preferences[SEARCH_DATE] = searchDate ?: ""
+        }
+    }
+
+    override fun getSearchDate(): Flow<String?> {
+        return dataStore.data.catch {
+            if (it is IOException) {
+                it.printStackTrace()
+                emit(emptyPreferences())
+            } else {
+                throw it
+            }
+        }.map { preferences ->
+            if (preferences[SEARCH_DATE] == "") {
+                null
+            } else {
+                preferences[SEARCH_DATE]
+            }
+        }
+    }
+
     companion object {
         private val DARK_MODE = booleanPreferencesKey("dark_mode")
+        private val CHARACTER_NAME = stringPreferencesKey("character_name")
+        private val CHARACTER_OCID = stringPreferencesKey("character_ocid")
+        private val SEARCH_DATE = stringPreferencesKey("search_date")
     }
 }

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterBasic.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterBasic.kt
@@ -8,7 +8,7 @@ data class CharacterBasic(
     val worldName: String = "",
     val characterGender: String = "",
     val characterClass: String = "",
-    val characterLevel: Int = 0,
+    val characterLevel: String = "",
     val characterGuildName: String? = null,
     val characterImage: String = ""
 )

--- a/app/src/main/java/com/bodan/maplecalendar/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/repository/SettingsRepository.kt
@@ -7,4 +7,16 @@ interface SettingsRepository {
     suspend fun setDarkMode()
 
     fun getDarkMode(): Flow<Boolean>
+
+    suspend fun setCharacterName(characterName: String)
+
+    fun getCharacterName(): Flow<String>
+
+    suspend fun setCharacterOcid(characterOcid: String)
+
+    fun getCharacterOcid(): Flow<String>
+
+    suspend fun setSearchDate(searchDate: String?)
+
+    fun getSearchDate(): Flow<String?>
 }

--- a/app/src/main/java/com/bodan/maplecalendar/domain/usecase/SetCharacterNameUseCase.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/usecase/SetCharacterNameUseCase.kt
@@ -1,0 +1,18 @@
+package com.bodan.maplecalendar.domain.usecase
+
+import com.bodan.maplecalendar.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SetCharacterNameUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository
+) {
+
+    suspend fun setCharacterName(characterName: String) {
+        settingsRepository.setCharacterName(characterName)
+    }
+
+    fun getCharacterName(): Flow<String> {
+        return settingsRepository.getCharacterName()
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/domain/usecase/SetCharacterOcidUseCase.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/usecase/SetCharacterOcidUseCase.kt
@@ -1,0 +1,18 @@
+package com.bodan.maplecalendar.domain.usecase
+
+import com.bodan.maplecalendar.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SetCharacterOcidUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository
+) {
+
+    suspend fun setCharacterOcid(characterOcid: String) {
+        settingsRepository.setCharacterOcid(characterOcid)
+    }
+
+    fun getCharacterOcid(): Flow<String> {
+        return settingsRepository.getCharacterOcid()
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/domain/usecase/SetSearchDateUseCase.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/usecase/SetSearchDateUseCase.kt
@@ -1,0 +1,18 @@
+package com.bodan.maplecalendar.domain.usecase
+
+import com.bodan.maplecalendar.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SetSearchDateUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository
+) {
+
+    suspend fun setSearchDate(searchDate: String?) {
+        settingsRepository.setSearchDate(searchDate)
+    }
+
+    fun getSearchDate(): Flow<String?> {
+        return settingsRepository.getSearchDate()
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/lobby/CustomCalendarAdapter.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/lobby/CustomCalendarAdapter.kt
@@ -6,7 +6,8 @@ import com.bodan.maplecalendar.app.MainApplication
 import com.bodan.maplecalendar.presentation.utils.DateFormatConverter
 import kotlin.math.abs
 
-class CustomCalendarAdapter(fm: FragmentActivity) : FragmentStateAdapter(fm) {
+class CustomCalendarAdapter(fm: FragmentActivity, private val searchDate: String) :
+    FragmentStateAdapter(fm) {
 
     private val dateFormatConverter = DateFormatConverter()
 
@@ -19,8 +20,6 @@ class CustomCalendarAdapter(fm: FragmentActivity) : FragmentStateAdapter(fm) {
     }
 
     override fun getItemId(position: Int): Long {
-        val searchDate =
-            MainApplication.mySharedPreferences.getSearchDate("searchDate", null) ?: return 0
         var currentYear = searchDate.substring(0, 4).toInt()
         var currentMonth = searchDate.substring(5, 7).toInt()
 

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/lobby/SearchDateFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/lobby/SearchDateFragment.kt
@@ -23,7 +23,6 @@ class SearchDateFragment :
         super.onViewCreated(view, savedInstanceState)
 
         initAdapter()
-        initCustomCalendar()
 
         binding.vm = viewModel
 
@@ -35,7 +34,14 @@ class SearchDateFragment :
     }
 
     private fun initAdapter() {
-        customCalendarAdapter = CustomCalendarAdapter(requireActivity())
+        lifecycleScope.launch {
+            viewModel.getSearchDate().collectLatest { searchDate ->
+                searchDate?.let {
+                    customCalendarAdapter = CustomCalendarAdapter(requireActivity(), searchDate)
+                    initCustomCalendar()
+                }
+            }
+        }
     }
 
     private fun initCustomCalendar() {

--- a/app/src/main/res/layout/fragment_lobby.xml
+++ b/app/src/main/res/layout/fragment_lobby.xml
@@ -222,7 +222,7 @@
                     app:layout_constraintBottom_toBottomOf="@id/tv_today_event_lobby"
                     app:layout_constraintStart_toEndOf="@id/gl_left_lobby"
                     app:layout_constraintTop_toBottomOf="@id/mcv_information_lobby"
-                    app:profileImage="@{vm.characterImage}" />
+                    app:profileImage="@{vm.characterBasic.characterImage}" />
 
                 <TextView
                     android:id="@+id/tv_level_lobby"
@@ -290,7 +290,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/guideline_large"
                     android:fontFamily="@font/pretendardregular"
-                    android:text="@{(vm.characterGender == null) ? @string/text_nothing : vm.characterGender}"
+                    android:text="@{(vm.characterBasic == null) ? @string/text_nothing : vm.characterBasic.characterGender}"
                     android:textSize="@dimen/font_size_medium"
                     app:layout_constraintBottom_toBottomOf="@id/tv_gender_lobby"
                     app:layout_constraintStart_toEndOf="@id/tv_gender_lobby"
@@ -301,7 +301,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@font/pretendardregular"
-                    android:text="@{(vm.characterGuild == null) ? @string/text_nothing : vm.characterGuild}"
+                    android:text="@{(vm.characterBasic.characterGuildName == null) ? @string/text_nothing : vm.characterBasic.characterGuildName}"
                     android:textSize="@dimen/font_size_medium"
                     app:layout_constraintBottom_toBottomOf="@id/tv_guild_lobby"
                     app:layout_constraintStart_toStartOf="@id/tv_character_gender_lobby"
@@ -312,7 +312,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@font/pretendardregular"
-                    android:text="@{(vm.characterWorld == null) ? @string/text_nothing : vm.characterWorld}"
+                    android:text="@{(vm.characterBasic == null) ? @string/text_nothing : vm.characterBasic.worldName}"
                     android:textSize="@dimen/font_size_medium"
                     app:layout_constraintBottom_toBottomOf="@id/tv_world_lobby"
                     app:layout_constraintStart_toStartOf="@id/tv_character_gender_lobby"
@@ -323,7 +323,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@font/pretendardregular"
-                    android:text="@{(vm.characterClass == null) ? @string/text_nothing : vm.characterClass}"
+                    android:text="@{(vm.characterBasic == null) ? @string/text_nothing : vm.characterBasic.characterClass}"
                     android:textSize="@dimen/font_size_medium"
                     app:layout_constraintBottom_toBottomOf="@id/tv_class_lobby"
                     app:layout_constraintStart_toStartOf="@id/tv_character_gender_lobby"
@@ -334,7 +334,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@font/pretendardregular"
-                    android:text="@{(vm.characterLevel == null) ? @string/text_nothing : vm.characterLevel.toString()}"
+                    android:text="@{(vm.characterBasic == null) ? @string/text_nothing : vm.characterBasic.characterLevel}"
                     android:textSize="@dimen/font_size_medium"
                     app:layout_constraintBottom_toBottomOf="@id/tv_level_lobby"
                     app:layout_constraintStart_toStartOf="@id/tv_character_gender_lobby"


### PR DESCRIPTION
# 2024. 05. 30
## 💭 Motivation
#### DataStore로 캐릭터의 닉네임, ocid, 조회 날짜도 관리하고자 하였다.

## 🔧 Changed
 - 다크모드와 마찬가지로 캐릭터의 닉네임, ocid, 조회 날짜 데이터를 초기화하고 가져오는 함수도 선언하고 정의한다.
 - 각각의 데이터마다 UseCase를 선언하여, 해당 UseCase에 의존한 ViewModel이 데이터를 초기화하고 가져올 수 있도록 한다.
 - 해당 데이터가 필요한 View는 ViewModel이 emit하는 데이터를 collect하고 UI를 그린다.
   - 캐릭터 조회 날짜를 선택하는 달력 View가 조회 날짜 데이터를 collect한 후 달력 UI를 그려낸다.

## 📝 To-Do
 - DataStore 관련 문서화 작업