### PR TITLE
[6/14] Bottom Sheet로 닉네임 변경 UI 추가

### DIFF
--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/setting/CharacterNameChangeDialogFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/setting/CharacterNameChangeDialogFragment.kt
@@ -1,0 +1,56 @@
+package com.bodan.maplecalendar.presentation.views.setting
+
+import android.os.Bundle
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
+import com.bodan.maplecalendar.R
+import com.bodan.maplecalendar.databinding.FragmentCharacterNameChangeDialogBinding
+import com.bodan.maplecalendar.presentation.views.MainViewModel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+class CharacterNameChangeDialogFragment : BottomSheetDialogFragment() {
+
+    private val viewModel: MainViewModel by activityViewModels()
+    private var _binding: FragmentCharacterNameChangeDialogBinding? = null
+    private val binding
+        get() = requireNotNull(_binding)
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = DataBindingUtil.inflate<FragmentCharacterNameChangeDialogBinding>(
+            inflater,
+            R.layout.fragment_character_name_change_dialog,
+            container,
+            false
+        )
+        binding.lifecycleOwner = viewLifecycleOwner
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.vm = viewModel
+
+        lifecycleScope.launch {
+            viewModel.settingUiEvent.collectLatest { uiEvent ->
+                if (uiEvent == SettingUiEvent.CloseChangeCharacterName) dismiss()
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/setting/SettingUiEvent.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/setting/SettingUiEvent.kt
@@ -2,6 +2,8 @@ package com.bodan.maplecalendar.presentation.views.setting
 
 sealed class SettingUiEvent {
 
+    data object GetWrongCharacterOcid : SettingUiEvent()
+
     data object ChangeCharacterName : SettingUiEvent()
 
     data object CloseChangeCharacterName : SettingUiEvent()

--- a/app/src/main/res/anim/modal_slide_in_bottom.xml
+++ b/app/src/main/res/anim/modal_slide_in_bottom.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <translate
+        android:duration="@android:integer/config_mediumAnimTime"
+        android:fromYDelta="100%p"
+        android:toYDelta="0" />
+
+</set>

--- a/app/src/main/res/anim/modal_slide_out_bottom.xml
+++ b/app/src/main/res/anim/modal_slide_out_bottom.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <translate
+        android:duration="@android:integer/config_mediumAnimTime"
+        android:fromYDelta="0"
+        android:toYDelta="100%p" />
+
+</set>

--- a/app/src/main/res/drawable/background_bottom_sheet.xml
+++ b/app/src/main/res/drawable/background_bottom_sheet.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <solid
+        android:color="@color/character"/>
+
+    <corners
+        android:topLeftRadius="40dp"
+        android:topRightRadius="40dp" />
+
+    <padding
+        android:left="10dp"
+        android:right="10dp"
+        android:top="10dp"
+        android:bottom="10dp" />
+
+</shape>

--- a/app/src/main/res/drawable/shape_submit.xml
+++ b/app/src/main/res/drawable/shape_submit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/listview_background_shape">
+
+    <corners android:radius="5dp" />
+
+    <solid android:color="@color/submit" />
+
+</shape>

--- a/app/src/main/res/drawable/shape_white.xml
+++ b/app/src/main/res/drawable/shape_white.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/listview_background_shape">
+
+    <corners android:radius="5dp" />
+
+    <solid android:color="@color/white" />
+
+</shape>

--- a/app/src/main/res/layout/fragment_character_name_change_dialog.xml
+++ b/app/src/main/res/layout/fragment_character_name_change_dialog.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="com.bodan.maplecalendar.presentation.views.MainViewModel" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/background_bottom_sheet">
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/gl_left_character_name_change_dialog"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_begin="@dimen/guideline_medium" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/gl_top_character_name_change_dialog"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_begin="@dimen/guideline_medium" />
+
+        <TextView
+            android:id="@+id/tv_title_character_name_change_dialog"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/pretendardbold"
+            android:text="@string/text_title_character_name_change_dialog"
+            android:textAlignment="viewStart"
+            android:textColor="@color/character_info"
+            android:textSize="@dimen/font_size_largest"
+            app:layout_constraintEnd_toStartOf="@id/ib_close_character_name_change_dialog"
+            app:layout_constraintStart_toEndOf="@id/gl_left_character_name_change_dialog"
+            app:layout_constraintTop_toBottomOf="@id/gl_top_character_name_change_dialog" />
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/ib_close_character_name_change_dialog"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@drawable/shape_close"
+            android:onClick="@{() -> vm.closeChangeCharacterName()}"
+            app:layout_constraintBottom_toBottomOf="@id/tv_title_character_name_change_dialog"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toStartOf="@id/gl_right_character_name_change_dialog"
+            app:layout_constraintTop_toBottomOf="@id/gl_top_character_name_change_dialog" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/mcv_character_name_change_dialog"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            app:cardCornerRadius="1dp"
+            app:layout_constraintBottom_toTopOf="@id/gl_bottom_character_name_change_dialog"
+            app:layout_constraintEnd_toStartOf="@id/gl_right_character_name_change_dialog"
+            app:layout_constraintStart_toEndOf="@id/gl_left_character_name_change_dialog"
+            app:layout_constraintTop_toBottomOf="@id/tv_title_character_name_change_dialog"
+            app:strokeWidth="0dp">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@drawable/shape_default_stat"
+                android:padding="@dimen/padding_medium">
+
+                <TextView
+                    android:id="@+id/tv_description_character_name_change_dialog"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@string/text_description_character_name_change"
+                    android:textAlignment="viewStart"
+                    android:textSize="@dimen/font_size_medium"
+                    app:layout_constraintBottom_toTopOf="@id/et_character_name_change_dialog"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <androidx.appcompat.widget.AppCompatEditText
+                    android:id="@+id/et_character_name_change_dialog"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/guideline_medium"
+                    android:layout_marginTop="@dimen/guideline_medium"
+                    android:layout_marginEnd="@dimen/guideline_medium"
+                    android:autofillHints="@null"
+                    android:background="@drawable/shape_white"
+                    android:ems="10"
+                    android:fontFamily="@font/pretendardregular"
+                    android:gravity="center_horizontal|center_vertical"
+                    android:hint="@string/description_character_nickname_edittext_hint"
+                    android:inputType="text"
+                    android:maxLength="12"
+                    android:onTextChanged="@{(characterName, s, b, c) -> vm.validateCharacterName(characterName)}"
+                    android:paddingTop="@dimen/padding_large"
+                    android:paddingBottom="@dimen/padding_large"
+                    android:text="@={vm.newCharacterName}"
+                    android:textAlignment="center"
+                    android:textSize="@dimen/font_size_large"
+                    app:layout_constraintBottom_toTopOf="@id/btn_validate_character_name_change_dialog"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_description_character_name_change_dialog" />
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/btn_validate_character_name_change_dialog"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/guideline_large"
+                    android:layout_marginTop="@dimen/guideline_medium"
+                    android:background="@{(vm.settingUiState.isSubmitBtnEnable == true) ? @drawable/shape_white : @drawable/shape_equipment_slot3}"
+                    android:enabled="@{vm.settingUiState.isSubmitBtnEnable}"
+                    android:onClick="@{() -> vm.validateCharacterOcid()}"
+                    android:padding="@dimen/padding_medium"
+                    android:text="@string/text_character_name_validate"
+                    android:textColor="@{(vm.settingUiState.isSubmitBtnEnable == true) ? @color/alert : @color/gray}"
+                    android:textSize="@dimen/font_size_medium"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/et_character_name_change_dialog" />
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/btn_submit_character_name_change_dialog"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/guideline_medium"
+                    android:layout_marginEnd="@dimen/guideline_large"
+                    android:background="@{(vm.newCharacterOcid == null) ? @drawable/shape_equipment_slot3 : @drawable/shape_submit}"
+                    android:enabled="@{(vm.newCharacterOcid == null) ? false : true}"
+                    android:onClick="@{() -> vm.submitChangeCharacterName()}"
+                    android:padding="@dimen/padding_medium"
+                    android:text="@string/text_character_name_change"
+                    android:textColor="@{(vm.newCharacterOcid == null) ? @color/gray : @color/white1}"
+                    android:textSize="@dimen/font_size_medium"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/et_character_name_change_dialog" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/gl_right_character_name_change_dialog"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_end="@dimen/guideline_medium" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/gl_bottom_character_name_change_dialog"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_end="@dimen/guideline_medium" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/navigation/nav_graph_main.xml
+++ b/app/src/main/res/navigation/nav_graph_main.xml
@@ -37,7 +37,7 @@
 
         <action
             android:id="@+id/action_setting_to_change_character_name"
-            app:destination="@id/fragment_change_character_name" />
+            app:destination="@id/fragment_character_name_change_dialog" />
 
         <action
             android:id="@+id/action_setting_to_push_notification"
@@ -64,5 +64,10 @@
         android:id="@+id/fragment_push_notification"
         android:name="com.bodan.maplecalendar.presentation.views.setting.PushNotificationFragment"
         android:label="@string/name_menu_set_push_notification" />
+
+    <dialog
+        android:id="@+id/fragment_character_name_change_dialog"
+        android:name="com.bodan.maplecalendar.presentation.views.setting.CharacterNameChangeDialogFragment"
+        android:label="@string/name_menu_character_name_change_dialog" />
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="name_menu_equipment">Equipment</string>
     <string name="name_menu_skill">Skill</string>
     <string name="name_menu_change_character_name">Change Character Name</string>
+    <string name="name_menu_character_name_change_dialog">Character Name Change Dialog</string>
     <string name="name_menu_set_push_notification">Set Push Notification</string>
     <string name="name_menu_day_event">Events of Date</string>
     <string name="name_menu_wait_equipment_detail">Wait For Item Equipment Detail</string>
@@ -71,6 +72,9 @@
     <string name="text_gender">성별</string>
     <string name="text_nickname_change">CHANGE NICKNAME</string>
     <string name="text_title_nickname_change">닉네임 변경</string>
+    <string name="text_description_character_name_change">조회할 캐릭터의 닉네임을 입력하고 유효한 캐릭터명인지 확인하세요.</string>
+    <string name="text_character_name_validate">닉네임 검증</string>
+    <string name="text_character_name_change">캐릭터 변경</string>
     <string name="text_change">변경</string>
     <string name="text_push_notification">EVENT NOTIFY</string>
     <string name="text_title_push_notification">이벤트 알림 설정</string>
@@ -210,6 +214,9 @@
     <string name="text_skill_level_next_left">[다음레벨</string>
     <string name="text_skill_level_right">]</string>
     <string name="text_owned_link_skill">내 링크 스킬</string>
+
+    <!-- Setting -->
+    <string name="text_title_character_name_change_dialog">캐릭터 닉네임 설정</string>
 
     <!-- Message -->
     <string name="message_network_error">네트워크에 오류가 있어요!</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -101,4 +101,13 @@
 
     </style>
 
+    <!-- Modal Bottom Sheet -->
+    <style name="DialogAnimation">
+        
+        <item name="android:windowEnterAnimation">@anim/modal_slide_in_bottom</item>
+
+        <item name="android:windowExitAnimation">@anim/modal_slide_out_bottom</item>
+        
+    </style>
+
 </resources>


### PR DESCRIPTION
# 2024. 06. 14
## 💭 Motivation
#### Modal Bottom Sheet로 닉네임 변경 UI를 추가하고자 하였다.

## 🔧 Changed
 - 캐릭터 닉네임 변경 버튼 터치 시 Modal Bottom Sheet 출력
   - Bottom Sheet 내부의 EditText에 조회를 원하는 캐릭터의 닉네임 입력
   - 조건에 맞는 닉네임인 경우 닉네임 검증 버튼 활성화
   - 닉네임 검증 버튼 터치 시 입력한 닉네임을 바탕으로 ocid 데이터를 가져옴
   - ocid가 존재하면 유효한 캐릭터라고 간주하고 캐릭터 변경 버튼 활성화, 캐릭터 변경 버튼 터치 시 Bottom Sheet가 닫히며 캐릭터 변경
   - ocid가 존재하지 않으면 유효하지 않은 캐릭터이므로 캐릭터 변경 버튼이 활성화되지 않음

## 📝 To-Do
 - UI 다듬기
 - 버그 파악

## ✅ Results
<p>
    <img width=250 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/3f8ed066-b72f-4cf4-9a3b-99be4dcec205">
</p>