### PR TITLE
[6/17] 캐릭터 닉네임 변경 UI 수정, 안드로이드 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,8 @@ dependencies {
     implementation("androidx.navigation:navigation-fragment-ktx:2.7.5")
     implementation("androidx.navigation:navigation-ui-ktx:2.7.5")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
+    implementation("androidx.legacy:legacy-support-v4:1.0.0")
+    implementation("androidx.recyclerview:recyclerview:1.3.2")
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/app/src/main/java/com/bodan/maplecalendar/data/api/MaplestoryApi.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/api/MaplestoryApi.kt
@@ -1,6 +1,7 @@
 package com.bodan.maplecalendar.data.api
 
 import com.bodan.maplecalendar.data.model.AbilityEntity
+import com.bodan.maplecalendar.data.model.AndroidEntity
 import com.bodan.maplecalendar.data.model.BasicEntity
 import com.bodan.maplecalendar.data.model.DojangEntity
 import com.bodan.maplecalendar.data.model.HyperStatEntity
@@ -82,4 +83,10 @@ interface MaplestoryApi {
         @Query("ocid") ocid: String,
         @Query("date") date: String?,
     ): Response<LinkSkillEntity>
+
+    @GET("v1/character/android-equipment")
+    suspend fun fetchCharacterAndroid(
+        @Query("ocid") ocid: String,
+        @Query("date") date: String?,
+    ): Response<AndroidEntity>
 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/mapper/CharacterAndroidMapper.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/mapper/CharacterAndroidMapper.kt
@@ -1,0 +1,109 @@
+package com.bodan.maplecalendar.data.mapper
+
+import com.bodan.maplecalendar.data.model.AndroidEntity
+import com.bodan.maplecalendar.domain.entity.CharacterAndroid
+import com.bodan.maplecalendar.domain.entity.CharacterAndroidFace
+import com.bodan.maplecalendar.domain.entity.CharacterAndroidHair
+import com.bodan.maplecalendar.domain.entity.CharacterAndroidInfo
+
+object CharacterAndroidMapper {
+
+    operator fun invoke(androidEntity: AndroidEntity): CharacterAndroid {
+        val androids = mutableListOf<CharacterAndroidInfo?>()
+
+        if (androidEntity.androidFirstPreset != null) {
+            androids.add(
+                CharacterAndroidInfo(
+                    androidName = androidEntity.androidFirstPreset.androidName,
+                    androidNickname = androidEntity.androidFirstPreset.androidNickname,
+                    androidIcon = androidEntity.androidFirstPreset.androidIcon,
+                    androidDescription = androidEntity.androidFirstPreset.androidDescription,
+                    androidGender = androidEntity.androidFirstPreset.androidGender,
+                    androidGrade = androidEntity.androidFirstPreset.androidGrade,
+                    androidSkinName = androidEntity.androidFirstPreset.androidSkinName,
+                    androidHair = CharacterAndroidHair(
+                        hairName = androidEntity.androidFirstPreset.androidHair.hairName,
+                        baseColor = androidEntity.androidFirstPreset.androidHair.baseColor,
+                        mixColor = androidEntity.androidFirstPreset.androidHair.mixColor,
+                        mixRate = androidEntity.androidFirstPreset.androidHair.mixRate
+                    ),
+                    androidFace = CharacterAndroidFace(
+                        faceName = androidEntity.androidFirstPreset.androidFace.faceName,
+                        baseColor = androidEntity.androidFirstPreset.androidFace.baseColor,
+                        mixColor = androidEntity.androidFirstPreset.androidFace.mixColor,
+                        mixRate = androidEntity.androidFirstPreset.androidFace.mixRate
+                    ),
+                    androidEarSensorClipFlag = androidEntity.androidFirstPreset.androidEarSensorClipFlag,
+                    androidNonHumanoidFlag = androidEntity.androidFirstPreset.androidNonHumanoidFlag,
+                    androidShopUsableFlag = androidEntity.androidFirstPreset.androidShopUsableFlag
+                )
+            )
+        } else {
+            androids.add(null)
+        }
+
+        if (androidEntity.androidSecondPreset != null) {
+            androids.add(
+                CharacterAndroidInfo(
+                    androidName = androidEntity.androidSecondPreset.androidName,
+                    androidNickname = androidEntity.androidSecondPreset.androidNickname,
+                    androidIcon = androidEntity.androidSecondPreset.androidIcon,
+                    androidDescription = androidEntity.androidSecondPreset.androidDescription,
+                    androidGender = androidEntity.androidSecondPreset.androidGender,
+                    androidGrade = androidEntity.androidSecondPreset.androidGrade,
+                    androidSkinName = androidEntity.androidSecondPreset.androidSkinName,
+                    androidHair = CharacterAndroidHair(
+                        hairName = androidEntity.androidSecondPreset.androidHair.hairName,
+                        baseColor = androidEntity.androidSecondPreset.androidHair.baseColor,
+                        mixColor = androidEntity.androidSecondPreset.androidHair.mixColor,
+                        mixRate = androidEntity.androidSecondPreset.androidHair.mixRate
+                    ),
+                    androidFace = CharacterAndroidFace(
+                        faceName = androidEntity.androidSecondPreset.androidFace.faceName,
+                        baseColor = androidEntity.androidSecondPreset.androidFace.baseColor,
+                        mixColor = androidEntity.androidSecondPreset.androidFace.mixColor,
+                        mixRate = androidEntity.androidSecondPreset.androidFace.mixRate
+                    ),
+                    androidEarSensorClipFlag = androidEntity.androidSecondPreset.androidEarSensorClipFlag,
+                    androidNonHumanoidFlag = androidEntity.androidSecondPreset.androidNonHumanoidFlag,
+                    androidShopUsableFlag = androidEntity.androidSecondPreset.androidShopUsableFlag
+                )
+            )
+        } else {
+            androids.add(androids[0])
+        }
+
+        if (androidEntity.androidThirdPreset != null) {
+            androids.add(
+                CharacterAndroidInfo(
+                    androidName = androidEntity.androidThirdPreset.androidName,
+                    androidNickname = androidEntity.androidThirdPreset.androidNickname,
+                    androidIcon = androidEntity.androidThirdPreset.androidIcon,
+                    androidDescription = androidEntity.androidThirdPreset.androidDescription,
+                    androidGender = androidEntity.androidThirdPreset.androidGender,
+                    androidGrade = androidEntity.androidThirdPreset.androidGrade,
+                    androidSkinName = androidEntity.androidThirdPreset.androidSkinName,
+                    androidHair = CharacterAndroidHair(
+                        hairName = androidEntity.androidThirdPreset.androidHair.hairName,
+                        baseColor = androidEntity.androidThirdPreset.androidHair.baseColor,
+                        mixColor = androidEntity.androidThirdPreset.androidHair.mixColor,
+                        mixRate = androidEntity.androidThirdPreset.androidHair.mixRate
+                    ),
+                    androidFace = CharacterAndroidFace(
+                        faceName = androidEntity.androidThirdPreset.androidFace.faceName,
+                        baseColor = androidEntity.androidThirdPreset.androidFace.baseColor,
+                        mixColor = androidEntity.androidThirdPreset.androidFace.mixColor,
+                        mixRate = androidEntity.androidThirdPreset.androidFace.mixRate
+                    ),
+                    androidEarSensorClipFlag = androidEntity.androidThirdPreset.androidEarSensorClipFlag,
+                    androidNonHumanoidFlag = androidEntity.androidThirdPreset.androidNonHumanoidFlag,
+                    androidShopUsableFlag = androidEntity.androidThirdPreset.androidShopUsableFlag
+                )
+            )
+        } else {
+            androids.add(androids[0])
+        }
+
+        return CharacterAndroid(androids = androids)
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/data/model/MaplestoryEntity.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/model/MaplestoryEntity.kt
@@ -646,3 +646,88 @@ data class LinkSkillInfoEntity(
     @Json(name = "skill_icon")
     val skillIcon: String
 )
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class AndroidEntity(
+    @Json(name = "android_preset_1")
+    val androidFirstPreset: AndroidInfoEntity?,
+
+    @Json(name = "android_preset_2")
+    val androidSecondPreset: AndroidInfoEntity?,
+
+    @Json(name = "android_preset_3")
+    val androidThirdPreset: AndroidInfoEntity?
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class AndroidInfoEntity(
+    @Json(name = "android_name")
+    val androidName: String,
+
+    @Json(name = "android_nickname")
+    val androidNickname: String,
+
+    @Json(name = "android_icon")
+    val androidIcon: String,
+
+    @Json(name = "android_description")
+    val androidDescription: String,
+
+    @Json(name = "android_gender")
+    val androidGender: String,
+
+    @Json(name = "android_grade")
+    val androidGrade: String,
+
+    @Json(name = "android_skin_name")
+    val androidSkinName: String?,
+
+    @Json(name = "android_hair")
+    val androidHair: AndroidHairEntity,
+
+    @Json(name = "android_face")
+    val androidFace: AndroidFaceEntity,
+
+    @Json(name = "android_ear_sensor_clip_flag")
+    val androidEarSensorClipFlag: String,
+
+    @Json(name = "android_non_humanoid_flag")
+    val androidNonHumanoidFlag: String,
+
+    @Json(name = "android_shop_usable_flag")
+    val androidShopUsableFlag: String
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class AndroidHairEntity(
+    @Json(name = "hair_name")
+    val hairName: String?,
+
+    @Json(name = "base_color")
+    val baseColor: String?,
+
+    @Json(name = "mix_color")
+    val mixColor: String?,
+
+    @Json(name = "mix_rate")
+    val mixRate: String
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class AndroidFaceEntity(
+    @Json(name = "face_name")
+    val faceName: String?,
+
+    @Json(name = "base_color")
+    val baseColor: String?,
+
+    @Json(name = "mix_color")
+    val mixColor: String?,
+
+    @Json(name = "mix_rate")
+    val mixRate: String
+)

--- a/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRemoteDataSource.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRemoteDataSource.kt
@@ -1,6 +1,7 @@
 package com.bodan.maplecalendar.data.repository
 
 import com.bodan.maplecalendar.data.model.AbilityEntity
+import com.bodan.maplecalendar.data.model.AndroidEntity
 import com.bodan.maplecalendar.data.model.BasicEntity
 import com.bodan.maplecalendar.data.model.DojangEntity
 import com.bodan.maplecalendar.data.model.HyperStatEntity
@@ -46,4 +47,6 @@ interface MaplestoryRemoteDataSource {
         ocid: String,
         date: String?
     ): Response<LinkSkillEntity>
+
+    suspend fun getCharacterAndroid(ocid: String, date: String?): Response<AndroidEntity>
 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRemoteDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.bodan.maplecalendar.data.repository
 
 import com.bodan.maplecalendar.data.api.MaplestoryApi
 import com.bodan.maplecalendar.data.model.AbilityEntity
+import com.bodan.maplecalendar.data.model.AndroidEntity
 import com.bodan.maplecalendar.data.model.BasicEntity
 import com.bodan.maplecalendar.data.model.DojangEntity
 import com.bodan.maplecalendar.data.model.HyperStatEntity
@@ -62,4 +63,7 @@ class MaplestoryRemoteDataSourceImpl @Inject constructor(
         ocid: String,
         date: String?
     ): Response<LinkSkillEntity> = maplestoryApi.fetchCharacterLinkSkill(ocid, date)
+
+    override suspend fun getCharacterAndroid(ocid: String, date: String?): Response<AndroidEntity> =
+        maplestoryApi.fetchCharacterAndroid(ocid, date)
 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRepositoryImpl.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.bodan.maplecalendar.data.repository
 
 import com.bodan.maplecalendar.data.mapper.CharacterAbilityMapper
+import com.bodan.maplecalendar.data.mapper.CharacterAndroidMapper
 import com.bodan.maplecalendar.domain.entity.CharacterDojang
 import com.bodan.maplecalendar.domain.entity.CharacterPopularity
 import com.bodan.maplecalendar.domain.entity.CharacterUnion
@@ -15,6 +16,7 @@ import com.bodan.maplecalendar.data.mapper.CharacterSkillMapper
 import com.bodan.maplecalendar.data.mapper.CharacterStatMapper
 import com.bodan.maplecalendar.data.mapper.CharacterUnionMapper
 import com.bodan.maplecalendar.domain.entity.CharacterAbility
+import com.bodan.maplecalendar.domain.entity.CharacterAndroid
 import com.bodan.maplecalendar.domain.entity.CharacterBasic
 import com.bodan.maplecalendar.domain.entity.CharacterHyperStat
 import com.bodan.maplecalendar.domain.entity.CharacterItemEquipment
@@ -219,6 +221,25 @@ class MaplestoryRepositoryImpl @Inject constructor(
             val body = response.body()
             if (response.isSuccessful && (body != null)) {
                 Result.success(CharacterLinkSkillMapper(body))
+            } else {
+                Result.error(response.errorBody().toString(), null)
+            }
+        } catch (e: Exception) {
+            Result.fail()
+        }
+
+    override suspend fun getCharacterAndroid(
+        ocid: String,
+        date: String?
+    ): Result<CharacterAndroid> =
+        try {
+            val response = withContext(CoroutineScope(Dispatchers.IO).coroutineContext) {
+                maplestoryRemoteDataSource.getCharacterAndroid(ocid, date)
+            }
+
+            val body = response.body()
+            if (response.isSuccessful && (body != null)) {
+                Result.success(CharacterAndroidMapper(body))
             } else {
                 Result.error(response.errorBody().toString(), null)
             }

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterAndroid.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterAndroid.kt
@@ -1,0 +1,8 @@
+package com.bodan.maplecalendar.domain.entity
+
+import androidx.annotation.Keep
+
+@Keep
+data class CharacterAndroid(
+    val androids: List<CharacterAndroidInfo?>
+)

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterAndroidFace.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterAndroidFace.kt
@@ -1,0 +1,11 @@
+package com.bodan.maplecalendar.domain.entity
+
+import androidx.annotation.Keep
+
+@Keep
+data class CharacterAndroidFace(
+    val faceName: String?,
+    val baseColor: String?,
+    val mixColor: String?,
+    val mixRate: String
+)

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterAndroidHair.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterAndroidHair.kt
@@ -1,0 +1,11 @@
+package com.bodan.maplecalendar.domain.entity
+
+import androidx.annotation.Keep
+
+@Keep
+data class CharacterAndroidHair(
+    val hairName: String?,
+    val baseColor: String?,
+    val mixColor: String?,
+    val mixRate: String
+)

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterAndroidInfo.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterAndroidInfo.kt
@@ -1,0 +1,19 @@
+package com.bodan.maplecalendar.domain.entity
+
+import androidx.annotation.Keep
+
+@Keep
+data class CharacterAndroidInfo(
+    val androidName: String,
+    val androidNickname: String,
+    val androidIcon: String,
+    val androidDescription: String,
+    val androidGender: String,
+    val androidGrade: String,
+    val androidSkinName: String?,
+    val androidHair: CharacterAndroidHair,
+    val androidFace: CharacterAndroidFace,
+    val androidEarSensorClipFlag: String,
+    val androidNonHumanoidFlag: String,
+    val androidShopUsableFlag: String
+)

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemBaseOption.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/ItemBaseOption.kt
@@ -20,5 +20,5 @@ data class ItemBaseOption(
     val itemBaseAllStat: String = "",
     val itemBaseMaxHpRate: String = "",
     val itemBaseMaxMpRate: String = "",
-    val itemBaseBaseEquipmentLevel: String = "",
+    val itemBaseBaseEquipmentLevel: String = "0",
 )

--- a/app/src/main/java/com/bodan/maplecalendar/domain/repository/MaplestoryRepository.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/repository/MaplestoryRepository.kt
@@ -1,6 +1,7 @@
 package com.bodan.maplecalendar.domain.repository
 
 import com.bodan.maplecalendar.domain.entity.CharacterAbility
+import com.bodan.maplecalendar.domain.entity.CharacterAndroid
 import com.bodan.maplecalendar.domain.entity.CharacterDojang
 import com.bodan.maplecalendar.domain.entity.CharacterItemEquipment
 import com.bodan.maplecalendar.domain.entity.CharacterBasic
@@ -46,4 +47,6 @@ interface MaplestoryRepository {
         ocid: String,
         date: String?
     ): Result<CharacterLinkSkill>
+
+    suspend fun getCharacterAndroid(ocid: String, date: String?): Result<CharacterAndroid>
 }

--- a/app/src/main/java/com/bodan/maplecalendar/domain/usecase/GetCharacterAndroidUseCase.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/usecase/GetCharacterAndroidUseCase.kt
@@ -1,0 +1,15 @@
+package com.bodan.maplecalendar.domain.usecase
+
+import com.bodan.maplecalendar.domain.entity.CharacterAndroid
+import com.bodan.maplecalendar.domain.entity.Result
+import com.bodan.maplecalendar.domain.repository.MaplestoryRepository
+import javax.inject.Inject
+
+class GetCharacterAndroidUseCase @Inject constructor(
+    private val maplestoryRepository: MaplestoryRepository
+) {
+
+    suspend fun getCharacterAndroid(ocid: String, date: String?): Result<CharacterAndroid> {
+        return maplestoryRepository.getCharacterAndroid(ocid, date)
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/AndroidDetailFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/AndroidDetailFragment.kt
@@ -1,0 +1,32 @@
+package com.bodan.maplecalendar.presentation.views.equipment
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
+import com.bodan.maplecalendar.R
+import com.bodan.maplecalendar.databinding.FragmentAndroidDetailBinding
+import com.bodan.maplecalendar.presentation.config.BaseDialogFragment
+import com.bodan.maplecalendar.presentation.views.CharacterViewModel
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class AndroidDetailFragment :
+    BaseDialogFragment<FragmentAndroidDetailBinding>(R.layout.fragment_android_detail) {
+
+    private val viewModel: CharacterViewModel by activityViewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.vm = viewModel
+
+        lifecycleScope.launch {
+            viewModel.equipmentUiEvent.collectLatest { uiEvent ->
+                if (uiEvent == EquipmentUiEvent.CloseItemEquipmentDetail) dismiss()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentFragment.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentFragment.kt
@@ -45,6 +45,10 @@ class EquipmentFragment : BaseFragment<FragmentEquipmentBinding>(R.layout.fragme
             findNavController().navigateSafely(R.id.action_equipment_to_item_equipment_detail)
         }
 
+        is EquipmentUiEvent.GetAndroidDetail -> {
+            findNavController().navigateSafely(R.id.action_equipment_to_android_detail)
+        }
+
         is EquipmentUiEvent.BadRequest -> {
             showSnackBar(R.string.message_bad_request)
         }

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentUiEvent.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentUiEvent.kt
@@ -8,6 +8,8 @@ sealed class EquipmentUiEvent {
 
     data object CloseItemEquipmentDetail : EquipmentUiEvent()
 
+    data object GetAndroidDetail : EquipmentUiEvent()
+
     data class GetDarkMode(val isDarkMode: Boolean?) : EquipmentUiEvent()
 
     data object BadRequest : EquipmentUiEvent()

--- a/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentUiState.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/presentation/views/equipment/EquipmentUiState.kt
@@ -79,8 +79,11 @@ sealed class EquipmentUiState(val id: String = UUID.randomUUID().toString()) {
             "${MainApplication.myContext().resources.getString(R.string.text_equipment_classified)} $itemEquipmentPart"
         val isAbleToUpgrade: Boolean =
             ((itemScrollUpgrade != "0") || (itemScrollUpgradableCount != "0"))
-        val itemUpgradeable: String =
-            "${MainApplication.myContext().resources.getString(R.string.text_equipment_scroll_upgradeable_count)} $itemScrollUpgradableCount"
+        val itemUpgradeable: String = when (itemEquipmentPart) {
+            "안드로이드" -> "${MainApplication.myContext().resources.getString(R.string.text_android_grade)} $itemScrollUpgradableCount"
+
+            else -> "${MainApplication.myContext().resources.getString(R.string.text_equipment_scroll_upgradeable_count)} $itemScrollUpgradableCount"
+        }
         val itemResilience: String =
             "(${MainApplication.myContext().resources.getString(R.string.text_equipment_scroll_resilience_count)} ${itemScrollResilienceCount})"
         val isGoldenHammerUsed: Boolean = (itemGoldenHammerFlag == "적용")

--- a/app/src/main/res/drawable/shape_bottom_sheet.xml
+++ b/app/src/main/res/drawable/shape_bottom_sheet.xml
@@ -5,8 +5,8 @@
         android:color="@color/character"/>
 
     <corners
-        android:topLeftRadius="40dp"
-        android:topRightRadius="40dp" />
+        android:topLeftRadius="20dp"
+        android:topRightRadius="20dp" />
 
     <padding
         android:left="10dp"

--- a/app/src/main/res/layout/fragment_android_detail.xml
+++ b/app/src/main/res/layout/fragment_android_detail.xml
@@ -1,0 +1,471 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <import type="android.view.View" />
+
+        <variable
+            name="vm"
+            type="com.bodan.maplecalendar.presentation.views.CharacterViewModel" />
+
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center">
+
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="330dp"
+                android:layout_height="wrap_content"
+                android:background="@drawable/shape_equipment_detail"
+                android:onClick="@{() -> vm.onItemEquipmentDetailClicked()}"
+                tools:context=".presentation.views.equipment.AndroidDetailFragment">
+
+                <androidx.constraintlayout.widget.Guideline
+                    android:id="@+id/gl_left_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    app:layout_constraintGuide_begin="@dimen/guideline_medium" />
+
+                <androidx.constraintlayout.widget.Guideline
+                    android:id="@+id/gl_top_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    app:layout_constraintGuide_begin="@dimen/guideline_medium" />
+
+                <TextView
+                    android:id="@+id/tv_name_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/guideline_minimum"
+                    android:fontFamily="@font/pretendardbold"
+                    android:text="@{vm.characterLastItemEquipment.itemName}"
+                    android:textColor="@color/white1"
+                    android:textSize="@dimen/font_size_large"
+                    app:layout_constraintBottom_toTopOf="@id/tv_name_android_detail"
+                    app:layout_constraintEnd_toStartOf="@id/gl_right_android_detail"
+                    app:layout_constraintStart_toEndOf="@id/gl_left_android_detail"
+                    app:layout_constraintTop_toBottomOf="@id/gl_top_android_detail" />
+
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:id="@+id/iv_dotted_first_android_detail"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/dot_height"
+                    android:layout_marginStart="@dimen/dot_margin_vertical"
+                    android:layout_marginTop="@dimen/guideline_smaller"
+                    android:layout_marginEnd="@dimen/dot_margin_vertical"
+                    android:layout_marginBottom="@dimen/guideline_smaller"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/ic_dotted"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_name_android_detail" />
+
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:id="@+id/iv_icon_android_detail"
+                    android:layout_width="100dp"
+                    android:layout_height="100dp"
+                    android:layout_marginTop="@dimen/guideline_small"
+                    android:padding="@dimen/padding_small"
+                    android:scaleType="fitCenter"
+                    app:image_background="@{vm.characterLastItemEquipment.itemIconBackground}"
+                    app:layout_constraintBottom_toTopOf="@id/mcv_class_android_detail"
+                    app:layout_constraintStart_toEndOf="@id/gl_left_android_detail"
+                    app:layout_constraintTop_toBottomOf="@id/iv_dotted_first_android_detail"
+                    app:profileImage="@{vm.characterLastItemEquipment.itemShapeIcon}" />
+
+                <TextView
+                    android:id="@+id/tv_req_dex_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/guideline_smaller"
+                    android:layout_marginBottom="@dimen/guideline_smaller"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@string/text_required_dex"
+                    android:textColor="@color/level"
+                    android:textSize="@dimen/font_size_smaller"
+                    app:layout_constraintBottom_toBottomOf="@id/iv_icon_android_detail"
+                    app:layout_constraintStart_toEndOf="@id/iv_icon_android_detail" />
+
+                <TextView
+                    android:id="@+id/tv_req_dex_stat_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/guideline_minimum"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@string/text_required_stat"
+                    android:textColor="@color/level"
+                    android:textSize="@dimen/font_size_smaller"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_req_dex_android_detail"
+                    app:layout_constraintStart_toEndOf="@id/tv_req_dex_android_detail"
+                    app:layout_constraintTop_toTopOf="@id/tv_req_dex_android_detail" />
+
+                <TextView
+                    android:id="@+id/tv_req_int_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@string/text_required_int"
+                    android:textColor="@color/level"
+                    android:textSize="@dimen/font_size_smaller"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_req_dex_android_detail"
+                    app:layout_constraintStart_toStartOf="@id/tv_req_luk_android_detail"
+                    app:layout_constraintTop_toTopOf="@id/tv_req_dex_android_detail" />
+
+                <TextView
+                    android:id="@+id/tv_req_int_stat_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/guideline_minimum"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@string/text_required_stat"
+                    android:textColor="@color/level"
+                    android:textSize="@dimen/font_size_smaller"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_req_dex_android_detail"
+                    app:layout_constraintEnd_toStartOf="@id/gl_right_android_detail"
+                    app:layout_constraintTop_toTopOf="@id/tv_req_dex_android_detail" />
+
+                <TextView
+                    android:id="@+id/tv_req_str_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/guideline_smaller"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@string/text_required_str"
+                    android:textColor="@color/level"
+                    android:textSize="@dimen/font_size_smaller"
+                    app:layout_constraintBottom_toTopOf="@id/tv_req_dex_android_detail"
+                    app:layout_constraintStart_toEndOf="@id/iv_icon_android_detail" />
+
+                <TextView
+                    android:id="@+id/tv_req_str_stat_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/guideline_minimum"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@string/text_required_stat"
+                    android:textColor="@color/level"
+                    android:textSize="@dimen/font_size_smaller"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_req_str_android_detail"
+                    app:layout_constraintEnd_toEndOf="@id/tv_req_dex_stat_android_detail"
+                    app:layout_constraintTop_toTopOf="@id/tv_req_str_android_detail" />
+
+                <TextView
+                    android:id="@+id/tv_req_luk_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/guideline_minimum"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@string/text_required_luk"
+                    android:textColor="@color/level"
+                    android:textSize="@dimen/font_size_smaller"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_req_str_android_detail"
+                    app:layout_constraintEnd_toStartOf="@id/tv_req_luk_stat_android_detail"
+                    app:layout_constraintTop_toTopOf="@id/tv_req_str_android_detail" />
+
+                <TextView
+                    android:id="@+id/tv_req_luk_stat_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@string/text_required_stat"
+                    android:textColor="@color/level"
+                    android:textSize="@dimen/font_size_smaller"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_req_str_android_detail"
+                    app:layout_constraintEnd_toStartOf="@id/gl_right_android_detail"
+                    app:layout_constraintTop_toTopOf="@id/tv_req_str_android_detail" />
+
+                <TextView
+                    android:id="@+id/tv_req_lev_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/guideline_smaller"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@string/text_required_lev"
+                    android:textColor="@{vm.characterLastItemEquipment.isReqLevZero ? @color/level : @color/equipment_starforce_option}"
+                    android:textSize="@dimen/font_size_smaller"
+                    app:layout_constraintBottom_toTopOf="@id/tv_req_str_android_detail"
+                    app:layout_constraintStart_toStartOf="@id/tv_req_str_android_detail" />
+
+                <TextView
+                    android:id="@+id/tv_req_lev_zero_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@string/text_required_lev_zero"
+                    android:textColor="@color/level"
+                    android:textSize="@dimen/font_size_smaller"
+                    android:visibility="@{vm.characterLastItemEquipment.isReqLevZero ? View.VISIBLE : View.GONE}"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_req_lev_android_detail"
+                    app:layout_constraintEnd_toEndOf="@id/tv_req_str_stat_android_detail"
+                    app:layout_constraintTop_toTopOf="@id/tv_req_lev_android_detail" />
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/mcv_class_android_detail"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/guideline_smaller"
+                    android:layout_marginBottom="@dimen/guideline_smaller"
+                    app:cardBackgroundColor="@color/equipment_detail"
+                    app:cardCornerRadius="1dp"
+                    app:layout_constraintBottom_toTopOf="@id/tv_shape_android_detail"
+                    app:layout_constraintEnd_toStartOf="@id/gl_right_android_detail"
+                    app:layout_constraintStart_toEndOf="@id/gl_left_android_detail"
+                    app:layout_constraintTop_toBottomOf="@id/iv_icon_android_detail"
+                    app:strokeWidth="0dp">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:background="@drawable/shape_class_background"
+                        android:paddingTop="@dimen/guideline_minimum"
+                        android:paddingBottom="@dimen/guideline_minimum">
+
+                        <TextView
+                            android:id="@+id/tv_beginner_mcv_class_android_detail"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/pretendardregular"
+                            android:text="@string/text_beginner"
+                            android:textColor="@color/level"
+                            android:textSize="@dimen/font_size_small"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/tv_warrior_mcv_class_android_detail"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <TextView
+                            android:id="@+id/tv_warrior_mcv_class_android_detail"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/pretendardregular"
+                            android:text="@string/text_warrior"
+                            android:textColor="@color/level"
+                            android:textSize="@dimen/font_size_small"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/tv_magician_mcv_class_android_detail"
+                            app:layout_constraintStart_toEndOf="@id/tv_beginner_mcv_class_android_detail"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <TextView
+                            android:id="@+id/tv_magician_mcv_class_android_detail"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/pretendardregular"
+                            android:text="@string/text_magician"
+                            android:textColor="@color/level"
+                            android:textSize="@dimen/font_size_small"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/tv_archer_mcv_class_android_detail"
+                            app:layout_constraintStart_toEndOf="@id/tv_warrior_mcv_class_android_detail"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <TextView
+                            android:id="@+id/tv_archer_mcv_class_android_detail"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/pretendardregular"
+                            android:text="@string/text_archer"
+                            android:textColor="@color/level"
+                            android:textSize="@dimen/font_size_small"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/tv_thief_mcv_class_android_detail"
+                            app:layout_constraintStart_toEndOf="@id/tv_magician_mcv_class_android_detail"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <TextView
+                            android:id="@+id/tv_thief_mcv_class_android_detail"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/pretendardregular"
+                            android:text="@string/text_thief"
+                            android:textColor="@color/level"
+                            android:textSize="@dimen/font_size_small"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/tv_pirate_mcv_class_android_detail"
+                            app:layout_constraintStart_toEndOf="@id/tv_archer_mcv_class_android_detail"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <TextView
+                            android:id="@+id/tv_pirate_mcv_class_android_detail"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/pretendardregular"
+                            android:text="@string/text_pirate"
+                            android:textColor="@color/level"
+                            android:textSize="@dimen/font_size_small"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toEndOf="@id/tv_thief_mcv_class_android_detail"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                </com.google.android.material.card.MaterialCardView>
+
+                <TextView
+                    android:id="@+id/tv_shape_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/guideline_smaller"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@string/text_android_shape"
+                    android:textColor="@color/white1"
+                    android:textSize="@dimen/font_size_small"
+                    app:layout_constraintStart_toEndOf="@id/gl_left_android_detail"
+                    app:layout_constraintTop_toBottomOf="@id/mcv_class_android_detail" />
+
+                <TextView
+                    android:id="@+id/tv_hair_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/guideline_smaller"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@{vm.characterLastItemEquipment.potentialOptionFirst}"
+                    android:textColor="@color/white1"
+                    android:textSize="@dimen/font_size_small"
+                    android:visibility="@{(vm.characterLastItemEquipment.potentialOptionFirst == null) ? View.GONE : View.VISIBLE}"
+                    app:layout_constraintStart_toEndOf="@id/gl_left_android_detail"
+                    app:layout_constraintTop_toBottomOf="@id/tv_shape_android_detail" />
+
+                <TextView
+                    android:id="@+id/tv_face_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@{vm.characterLastItemEquipment.potentialOptionSecond}"
+                    android:textColor="@color/white1"
+                    android:textSize="@dimen/font_size_small"
+                    android:visibility="@{(vm.characterLastItemEquipment.potentialOptionSecond == null) ? View.GONE : View.VISIBLE}"
+                    app:layout_constraintStart_toEndOf="@id/gl_left_android_detail"
+                    app:layout_constraintTop_toBottomOf="@id/tv_hair_android_detail" />
+
+                <TextView
+                    android:id="@+id/tv_skin_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@{vm.characterLastItemEquipment.potentialOptionThird}"
+                    android:textColor="@color/white1"
+                    android:textSize="@dimen/font_size_small"
+                    android:visibility="@{(vm.characterLastItemEquipment.potentialOptionThird == null) ? View.GONE : View.VISIBLE}"
+                    app:layout_constraintStart_toEndOf="@id/gl_left_android_detail"
+                    app:layout_constraintTop_toBottomOf="@id/tv_face_android_detail" />
+
+                <androidx.constraintlayout.widget.Barrier
+                    android:id="@+id/barrier_shape_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:barrierAllowsGoneWidgets="true"
+                    app:barrierDirection="bottom"
+                    app:constraint_referenced_ids="tv_hair_android_detail,tv_face_android_detail,tv_skin_android_detail"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:id="@+id/iv_dotted_second_android_default"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/dot_height"
+                    android:layout_marginStart="@dimen/dot_margin_vertical"
+                    android:layout_marginTop="@dimen/guideline_smaller"
+                    android:layout_marginEnd="@dimen/dot_margin_vertical"
+                    android:layout_marginBottom="@dimen/guideline_smaller"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/ic_dotted"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/barrier_shape_android_detail" />
+
+                <TextView
+                    android:id="@+id/tv_classified_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/guideline_smaller"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@{vm.characterLastItemEquipment.itemClassified}"
+                    android:textColor="@color/white1"
+                    android:textSize="@dimen/font_size_small"
+                    app:layout_constraintStart_toEndOf="@id/gl_left_android_detail"
+                    app:layout_constraintTop_toBottomOf="@id/iv_dotted_second_android_default" />
+
+                <TextView
+                    android:id="@+id/tv_grade_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@{vm.characterLastItemEquipment.itemUpgradeable}"
+                    android:textColor="@color/white1"
+                    android:textSize="@dimen/font_size_small"
+                    app:layout_constraintStart_toEndOf="@id/gl_left_android_detail"
+                    app:layout_constraintTop_toBottomOf="@id/tv_classified_android_detail" />
+
+                <TextView
+                    android:id="@+id/tv_not_able_to_set_potential_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@string/text_not_able_to_set_potential"
+                    android:textColor="@color/white1"
+                    android:textSize="@dimen/font_size_small"
+                    app:layout_constraintStart_toEndOf="@id/gl_left_android_detail"
+                    app:layout_constraintTop_toBottomOf="@id/tv_grade_android_detail" />
+
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:id="@+id/iv_dotted_third_android_default"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/dot_height"
+                    android:layout_marginStart="@dimen/dot_margin_vertical"
+                    android:layout_marginTop="@dimen/guideline_smaller"
+                    android:layout_marginEnd="@dimen/dot_margin_vertical"
+                    android:layout_marginBottom="@dimen/guideline_smaller"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/ic_dotted"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_not_able_to_set_potential_android_detail" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/guideline_smaller"
+                    android:fontFamily="@font/pretendardregular"
+                    android:text="@{vm.characterLastItemEquipment.itemDescription}"
+                    android:textColor="@color/white1"
+                    android:textSize="@dimen/font_size_small"
+                    app:layout_constraintBottom_toTopOf="@id/gl_bottom_android_detail"
+                    app:layout_constraintEnd_toStartOf="@id/gl_right_android_detail"
+                    app:layout_constraintStart_toEndOf="@id/gl_left_android_detail"
+                    app:layout_constraintTop_toBottomOf="@id/iv_dotted_third_android_default" />
+
+                <androidx.constraintlayout.widget.Guideline
+                    android:id="@+id/gl_right_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    app:layout_constraintGuide_end="@dimen/guideline_medium" />
+
+                <androidx.constraintlayout.widget.Guideline
+                    android:id="@+id/gl_bottom_android_detail"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    app:layout_constraintGuide_end="@dimen/guideline_medium" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </androidx.core.widget.NestedScrollView>
+
+    </LinearLayout>
+
+</layout>

--- a/app/src/main/res/layout/fragment_character_name_change_dialog.xml
+++ b/app/src/main/res/layout/fragment_character_name_change_dialog.xml
@@ -14,7 +14,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@drawable/background_bottom_sheet">
+        android:background="@drawable/shape_bottom_sheet">
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/gl_left_character_name_change_dialog"
@@ -58,8 +58,10 @@
             android:id="@+id/mcv_character_name_change_dialog"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:background="@android:color/transparent"
-            app:cardCornerRadius="1dp"
+            android:layout_marginTop="@dimen/guideline_medium"
+            android:layout_marginBottom="@dimen/guideline_medium"
+            app:cardBackgroundColor="@android:color/transparent"
+            app:cardCornerRadius="0dp"
             app:layout_constraintBottom_toTopOf="@id/gl_bottom_character_name_change_dialog"
             app:layout_constraintEnd_toStartOf="@id/gl_right_character_name_change_dialog"
             app:layout_constraintStart_toEndOf="@id/gl_left_character_name_change_dialog"

--- a/app/src/main/res/layout/fragment_item_equipment_detail.xml
+++ b/app/src/main/res/layout/fragment_item_equipment_detail.xml
@@ -785,7 +785,6 @@
                     app:layout_constraintStart_toEndOf="@id/tv_exceptional_all_stat_item_equipment_default"
                     app:layout_constraintTop_toTopOf="@id/tv_exceptional_all_stat_item_equipment_default" />
 
-
                 <TextView
                     android:id="@+id/tv_exceptional_hp_mp_item_equipment_default"
                     android:layout_width="wrap_content"
@@ -859,7 +858,7 @@
                     app:barrierAllowsGoneWidgets="true"
                     app:barrierDirection="bottom"
                     app:barrierMargin="@dimen/guideline_minimum"
-                    app:constraint_referenced_ids="tv_exceptional_used_item_equipment_detail"
+                    app:constraint_referenced_ids="tv_exceptional_none_item_equipment_detail,tv_exceptional_used_item_equipment_detail"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_exceptional_used_item_equipment_detail" />

--- a/app/src/main/res/navigation/nav_graph_character.xml
+++ b/app/src/main/res/navigation/nav_graph_character.xml
@@ -31,6 +31,10 @@
             android:id="@+id/action_equipment_to_item_equipment_detail"
             app:destination="@id/fragment_item_equipment_detail" />
 
+        <action
+            android:id="@+id/action_equipment_to_android_detail"
+            app:destination="@id/fragment_android_detail" />
+
     </fragment>
 
     <fragment
@@ -57,6 +61,11 @@
         android:id="@+id/fragment_item_equipment_detail"
         android:name="com.bodan.maplecalendar.presentation.views.equipment.ItemEquipmentDetailFragment"
         android:label="@string/name_menu_item_equipment_detail" />
+
+    <dialog
+        android:id="@+id/fragment_android_detail"
+        android:name="com.bodan.maplecalendar.presentation.views.equipment.AndroidDetailFragment"
+        android:label="@string/name_menu_android_detail" />
 
     <dialog
         android:id="@+id/fragment_hyper_stat"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="name_menu_day_event">Events of Date</string>
     <string name="name_menu_wait_equipment_detail">Wait For Item Equipment Detail</string>
     <string name="name_menu_item_equipment_detail">Item Equipment Detail</string>
+    <string name="name_menu_android_detail">Android Detail</string>
     <string name="name_search_date">Search Date</string>
     <string name="name_hyper_stat">Hyper Stat</string>
     <string name="name_ability">Ability</string>
@@ -152,6 +153,8 @@
     <string name="text_pirate">해적</string>
     <string name="text_superior">슈페리얼</string>
     <string name="text_equipment_classified">장비분류 : </string>
+    <string name="text_android_shape">외형 : </string>
+    <string name="text_android_grade">등급 : </string>
     <string name="text_left_bracket">(</string>
     <string name="text_right_bracket">)</string>
     <string name="text_equipment_str">STR : +</string>
@@ -183,6 +186,7 @@
     <string name="text_exceptional_used">익셉셔널 강화 1회 적용 (최대 1회 강화 가능)</string>
     <string name="text_exceptional_hp_mp">최대 HP / 최대 MP : +</string>
     <string name="text_exceptional_attack_magic_power">공격력 / 마력 : +</string>
+    <string name="text_not_able_to_set_potential">잠재능력 설정 불가</string>
 
     <!-- Hyper Stat -->
     <string name="text_hyper_stat">하이퍼 스탯</string>


### PR DESCRIPTION
# 2024. 06. 17
## 💭 Motivation
#### 캐릭터 닉네임 변경에 사용한 Bottom Sheet를 좀 더 자연스럽게 수정하고자 하였다.
#### 또한 장비창에 안드로이드를 보여주고자 하였다.

## 🔧 Changed
#### Bottom Sheet
 - UI 상으로 어색한 부분이 없게 수정하였다.

#### 안드로이드
 - 안드로이드 데이터를 가져왔고, CharacterAndroid 데이터 클래스로 데이터를 담을 수 있도록 하였다.
 - 다만 장비창에 안드로이드가 포함되어야 하는데 EquipmentUiState.EquipmentOption으로 추가해야 했기 때문에 ViewModel에서 그 과정을 거쳐 안드로이드를 장비 List에 추가하였다.

## 📝 To-Do
 - 캐시장비 데이터를 가져오고, 장비창 내부를 좌우 스와이프하여 장비, 캐시장비, 안드로이드 장비를 볼 수 있도록 할 것이다.

## ✅ Results
<p>
    <img width=250 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/095e38dd-80fc-4676-8dd0-dd4fa0f68d86">
    <img width=250 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/3f5dddb7-eede-441e-816f-25a37de11940">
    <img width=250 src="https://github.com/littlesam95/MapleCalendar/assets/55424662/76436827-e0a3-437d-bdc9-30baf1906233">
</p>

Closes: #76, #78 