### PR TITLE
[6/18] 캐시 아이템 데이터 받아오기

### DIFF
--- a/app/src/main/java/com/bodan/maplecalendar/data/api/MaplestoryApi.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/api/MaplestoryApi.kt
@@ -3,6 +3,7 @@ package com.bodan.maplecalendar.data.api
 import com.bodan.maplecalendar.data.model.AbilityEntity
 import com.bodan.maplecalendar.data.model.AndroidEntity
 import com.bodan.maplecalendar.data.model.BasicEntity
+import com.bodan.maplecalendar.data.model.CashItemEntity
 import com.bodan.maplecalendar.data.model.DojangEntity
 import com.bodan.maplecalendar.data.model.HyperStatEntity
 import com.bodan.maplecalendar.data.model.ItemEquipmentEntity
@@ -89,4 +90,10 @@ interface MaplestoryApi {
         @Query("ocid") ocid: String,
         @Query("date") date: String?,
     ): Response<AndroidEntity>
+
+    @GET("v1/character/cashitem-equipment")
+    suspend fun fetchCharacterCashItem(
+        @Query("ocid") ocid: String,
+        @Query("date") date: String?,
+    ): Response<CashItemEntity>
 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/mapper/CharacterCashItemMapper.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/mapper/CharacterCashItemMapper.kt
@@ -1,0 +1,162 @@
+package com.bodan.maplecalendar.data.mapper
+
+import com.bodan.maplecalendar.data.model.CashItemEntity
+import com.bodan.maplecalendar.data.model.CashItemInfoEntity
+import com.bodan.maplecalendar.domain.entity.CharacterCashItem
+import com.bodan.maplecalendar.domain.entity.CharacterCashItemColoringPrism
+import com.bodan.maplecalendar.domain.entity.CharacterCashItemInfo
+import com.bodan.maplecalendar.domain.entity.CharacterCashItemOption
+
+object CharacterCashItemMapper {
+
+    private fun getCashItemInfos(cashItemInfos: List<CashItemInfoEntity>): List<CharacterCashItemInfo> {
+        val result = mutableListOf<CharacterCashItemInfo>()
+
+        cashItemInfos.forEach { cashItemInfo ->
+            val newCashItemOptions = mutableListOf<CharacterCashItemOption>()
+            cashItemInfo.cashItemOption.forEach { option ->
+                newCashItemOptions.add(
+                    CharacterCashItemOption(
+                        optionType = option.optionType,
+                        optionValue = option.optionValue
+                    )
+                )
+            }
+
+            result.add(
+                CharacterCashItemInfo(
+                    cashItemEquipmentPart = cashItemInfo.cashItemEquipmentPart,
+                    cashItemEquipmentSlot = cashItemInfo.cashItemEquipmentSlot,
+                    cashItemName = cashItemInfo.cashItemName,
+                    cashItemIcon = cashItemInfo.cashItemIcon,
+                    cashItemDescription = cashItemInfo.cashItemDescription,
+                    cashItemOption = newCashItemOptions,
+                    dateExpire = cashItemInfo.dateExpire,
+                    dateOptionExpire = cashItemInfo.dateOptionExpire,
+                    cashItemLabel = cashItemInfo.cashItemLabel,
+                    cashItemColoringPrism = when (cashItemInfo.cashItemColoringPrism) {
+                        null -> null
+
+                        else -> CharacterCashItemColoringPrism(
+                            colorRange = cashItemInfo.cashItemColoringPrism.colorRange,
+                            hue = cashItemInfo.cashItemColoringPrism.hue.toString(),
+                            saturation = cashItemInfo.cashItemColoringPrism.saturation.toString(),
+                            value = cashItemInfo.cashItemColoringPrism.value.toString()
+                        )
+                    },
+                    itemGender = cashItemInfo.itemGender
+                )
+            )
+        }
+
+        return result.toList()
+    }
+
+    operator fun invoke(cashItemEntity: CashItemEntity): CharacterCashItem {
+        val newCashItemEquipmentBase = mutableListOf<CharacterCashItemInfo>()
+        val newCashItemEquipmentPresets = mutableListOf<List<CharacterCashItemInfo>>()
+        val newAdditionalCashItemEquipmentBase = mutableListOf<CharacterCashItemInfo>()
+        val newAdditionalCashItemEquipmentPresets = mutableListOf<List<CharacterCashItemInfo>>()
+
+        cashItemEntity.cashItemEquipmentBase.forEach { cashItemInfo ->
+            val newCashItemOptions = mutableListOf<CharacterCashItemOption>()
+            cashItemInfo.cashItemOption.forEach { option ->
+                newCashItemOptions.add(
+                    CharacterCashItemOption(
+                        optionType = option.optionType,
+                        optionValue = option.optionValue
+                    )
+                )
+            }
+
+            newCashItemEquipmentBase.add(
+                CharacterCashItemInfo(
+                    cashItemEquipmentPart = cashItemInfo.cashItemEquipmentPart,
+                    cashItemEquipmentSlot = cashItemInfo.cashItemEquipmentSlot,
+                    cashItemName = cashItemInfo.cashItemName,
+                    cashItemIcon = cashItemInfo.cashItemIcon,
+                    cashItemDescription = cashItemInfo.cashItemDescription,
+                    cashItemOption = newCashItemOptions,
+                    dateExpire = cashItemInfo.dateExpire,
+                    dateOptionExpire = cashItemInfo.dateOptionExpire,
+                    cashItemLabel = cashItemInfo.cashItemLabel,
+                    cashItemColoringPrism = when (cashItemInfo.cashItemColoringPrism) {
+                        null -> null
+
+                        else -> CharacterCashItemColoringPrism(
+                            colorRange = cashItemInfo.cashItemColoringPrism.colorRange,
+                            hue = cashItemInfo.cashItemColoringPrism.hue.toString(),
+                            saturation = cashItemInfo.cashItemColoringPrism.saturation.toString(),
+                            value = cashItemInfo.cashItemColoringPrism.value.toString()
+                        )
+                    },
+                    itemGender = cashItemInfo.itemGender
+                )
+            )
+        }
+
+        newCashItemEquipmentPresets.add(
+            getCashItemInfos(cashItemEntity.cashItemEquipmentFirstPreset)
+        )
+        newCashItemEquipmentPresets.add(
+            getCashItemInfos(cashItemEntity.cashItemEquipmentSecondPreset)
+        )
+        newCashItemEquipmentPresets.add(
+            getCashItemInfos(cashItemEntity.cashItemEquipmentThirdPreset)
+        )
+
+        cashItemEntity.additionalCashItemEquipmentBase.forEach { cashItemInfo ->
+            val newCashItemOptions = mutableListOf<CharacterCashItemOption>()
+            cashItemInfo.cashItemOption.forEach { option ->
+                newCashItemOptions.add(
+                    CharacterCashItemOption(
+                        optionType = option.optionType,
+                        optionValue = option.optionValue
+                    )
+                )
+            }
+
+            newAdditionalCashItemEquipmentBase.add(
+                CharacterCashItemInfo(
+                    cashItemEquipmentPart = cashItemInfo.cashItemEquipmentPart,
+                    cashItemEquipmentSlot = cashItemInfo.cashItemEquipmentSlot,
+                    cashItemName = cashItemInfo.cashItemName,
+                    cashItemIcon = cashItemInfo.cashItemIcon,
+                    cashItemDescription = cashItemInfo.cashItemDescription,
+                    cashItemOption = newCashItemOptions,
+                    dateExpire = cashItemInfo.dateExpire,
+                    dateOptionExpire = cashItemInfo.dateOptionExpire,
+                    cashItemLabel = cashItemInfo.cashItemLabel,
+                    cashItemColoringPrism = when (cashItemInfo.cashItemColoringPrism) {
+                        null -> null
+
+                        else -> CharacterCashItemColoringPrism(
+                            colorRange = cashItemInfo.cashItemColoringPrism.colorRange,
+                            hue = cashItemInfo.cashItemColoringPrism.hue.toString(),
+                            saturation = cashItemInfo.cashItemColoringPrism.saturation.toString(),
+                            value = cashItemInfo.cashItemColoringPrism.value.toString()
+                        )
+                    },
+                    itemGender = cashItemInfo.itemGender
+                )
+            )
+        }
+
+        newAdditionalCashItemEquipmentPresets.add(
+            getCashItemInfos(cashItemEntity.additionalCashItemEquipmentFirstPreset)
+        )
+        newAdditionalCashItemEquipmentPresets.add(
+            getCashItemInfos(cashItemEntity.additionalCashItemEquipmentSecondPreset)
+        )
+        newAdditionalCashItemEquipmentPresets.add(
+            getCashItemInfos(cashItemEntity.additionalCashItemEquipmentThirdPreset)
+        )
+
+        return CharacterCashItem(
+            cashItemEquipmentBase = newCashItemEquipmentBase,
+            cashItemEquipmentPresets = newCashItemEquipmentPresets,
+            additionalCashItemEquipmentBase = newAdditionalCashItemEquipmentBase,
+            additionalCashItemEquipmentPresets = newAdditionalCashItemEquipmentPresets
+        )
+    }
+}

--- a/app/src/main/java/com/bodan/maplecalendar/data/model/MaplestoryEntity.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/model/MaplestoryEntity.kt
@@ -731,3 +731,94 @@ data class AndroidFaceEntity(
     @Json(name = "mix_rate")
     val mixRate: String
 )
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class CashItemEntity(
+    @Json(name = "cash_item_equipment_base")
+    val cashItemEquipmentBase: List<CashItemInfoEntity>,
+
+    @Json(name = "cash_item_equipment_preset_1")
+    val cashItemEquipmentFirstPreset: List<CashItemInfoEntity>,
+
+    @Json(name = "cash_item_equipment_preset_2")
+    val cashItemEquipmentSecondPreset: List<CashItemInfoEntity>,
+
+    @Json(name = "cash_item_equipment_preset_3")
+    val cashItemEquipmentThirdPreset: List<CashItemInfoEntity>,
+
+    @Json(name = "additional_cash_item_equipment_base")
+    val additionalCashItemEquipmentBase: List<CashItemInfoEntity>,
+
+    @Json(name = "additional_cash_item_equipment_preset_1")
+    val additionalCashItemEquipmentFirstPreset: List<CashItemInfoEntity>,
+
+    @Json(name = "additional_cash_item_equipment_preset_2")
+    val additionalCashItemEquipmentSecondPreset: List<CashItemInfoEntity>,
+
+    @Json(name = "additional_cash_item_equipment_preset_3")
+    val additionalCashItemEquipmentThirdPreset: List<CashItemInfoEntity>
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class CashItemInfoEntity(
+    @Json(name = "cash_item_equipment_part")
+    val cashItemEquipmentPart: String,
+
+    @Json(name = "cash_item_equipment_slot")
+    val cashItemEquipmentSlot: String,
+
+    @Json(name = "cash_item_name")
+    val cashItemName: String,
+
+    @Json(name = "cash_item_icon")
+    val cashItemIcon: String,
+
+    @Json(name = "cash_item_description")
+    val cashItemDescription: String?,
+
+    @Json(name = "cash_item_option")
+    val cashItemOption: List<CashItemOptionEntity>,
+
+    @Json(name = "date_expire")
+    val dateExpire: String?,
+
+    @Json(name = "date_option_expire")
+    val dateOptionExpire: String?,
+
+    @Json(name = "cash_item_label")
+    val cashItemLabel: String?,
+
+    @Json(name = "cash_item_coloring_prism")
+    val cashItemColoringPrism: CashItemColoringPrismEntity?,
+
+    @Json(name = "item_gender")
+    val itemGender: String?
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class CashItemOptionEntity(
+    @Json(name = "option_type")
+    val optionType: String,
+
+    @Json(name = "option_value")
+    val optionValue: String
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class CashItemColoringPrismEntity(
+    @Json(name = "color_range")
+    val colorRange: String,
+
+    @Json(name = "hue")
+    val hue: Long,
+
+    @Json(name = "saturation")
+    val saturation: Long,
+
+    @Json(name = "value")
+    val value: Long
+)

--- a/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRemoteDataSource.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRemoteDataSource.kt
@@ -3,6 +3,7 @@ package com.bodan.maplecalendar.data.repository
 import com.bodan.maplecalendar.data.model.AbilityEntity
 import com.bodan.maplecalendar.data.model.AndroidEntity
 import com.bodan.maplecalendar.data.model.BasicEntity
+import com.bodan.maplecalendar.data.model.CashItemEntity
 import com.bodan.maplecalendar.data.model.DojangEntity
 import com.bodan.maplecalendar.data.model.HyperStatEntity
 import com.bodan.maplecalendar.data.model.ItemEquipmentEntity
@@ -49,4 +50,6 @@ interface MaplestoryRemoteDataSource {
     ): Response<LinkSkillEntity>
 
     suspend fun getCharacterAndroid(ocid: String, date: String?): Response<AndroidEntity>
+
+    suspend fun getCharacterCashItem(ocid: String, date: String?): Response<CashItemEntity>
 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRemoteDataSourceImpl.kt
@@ -4,6 +4,7 @@ import com.bodan.maplecalendar.data.api.MaplestoryApi
 import com.bodan.maplecalendar.data.model.AbilityEntity
 import com.bodan.maplecalendar.data.model.AndroidEntity
 import com.bodan.maplecalendar.data.model.BasicEntity
+import com.bodan.maplecalendar.data.model.CashItemEntity
 import com.bodan.maplecalendar.data.model.DojangEntity
 import com.bodan.maplecalendar.data.model.HyperStatEntity
 import com.bodan.maplecalendar.data.model.ItemEquipmentEntity
@@ -66,4 +67,9 @@ class MaplestoryRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun getCharacterAndroid(ocid: String, date: String?): Response<AndroidEntity> =
         maplestoryApi.fetchCharacterAndroid(ocid, date)
+
+    override suspend fun getCharacterCashItem(
+        ocid: String,
+        date: String?
+    ): Response<CashItemEntity> = maplestoryApi.fetchCharacterCashItem(ocid, date)
 }

--- a/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRepositoryImpl.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/data/repository/MaplestoryRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.bodan.maplecalendar.domain.entity.CharacterDojang
 import com.bodan.maplecalendar.domain.entity.CharacterPopularity
 import com.bodan.maplecalendar.domain.entity.CharacterUnion
 import com.bodan.maplecalendar.data.mapper.CharacterBasicMapper
+import com.bodan.maplecalendar.data.mapper.CharacterCashItemMapper
 import com.bodan.maplecalendar.data.mapper.CharacterDojangMapper
 import com.bodan.maplecalendar.data.mapper.CharacterHyperStatMapper
 import com.bodan.maplecalendar.data.mapper.CharacterItemEquipmentMapper
@@ -18,6 +19,7 @@ import com.bodan.maplecalendar.data.mapper.CharacterUnionMapper
 import com.bodan.maplecalendar.domain.entity.CharacterAbility
 import com.bodan.maplecalendar.domain.entity.CharacterAndroid
 import com.bodan.maplecalendar.domain.entity.CharacterBasic
+import com.bodan.maplecalendar.domain.entity.CharacterCashItem
 import com.bodan.maplecalendar.domain.entity.CharacterHyperStat
 import com.bodan.maplecalendar.domain.entity.CharacterItemEquipment
 import com.bodan.maplecalendar.domain.entity.CharacterLinkSkill
@@ -240,6 +242,25 @@ class MaplestoryRepositoryImpl @Inject constructor(
             val body = response.body()
             if (response.isSuccessful && (body != null)) {
                 Result.success(CharacterAndroidMapper(body))
+            } else {
+                Result.error(response.errorBody().toString(), null)
+            }
+        } catch (e: Exception) {
+            Result.fail()
+        }
+
+    override suspend fun getCharacterCashItem(
+        ocid: String,
+        date: String?
+    ): Result<CharacterCashItem> =
+        try {
+            val response = withContext(CoroutineScope(Dispatchers.IO).coroutineContext) {
+                maplestoryRemoteDataSource.getCharacterCashItem(ocid, date)
+            }
+
+            val body = response.body()
+            if (response.isSuccessful && (body != null)) {
+                Result.success(CharacterCashItemMapper(body))
             } else {
                 Result.error(response.errorBody().toString(), null)
             }

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterCashItem.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterCashItem.kt
@@ -1,0 +1,11 @@
+package com.bodan.maplecalendar.domain.entity
+
+import androidx.annotation.Keep
+
+@Keep
+data class CharacterCashItem(
+    val cashItemEquipmentBase: List<CharacterCashItemInfo>,
+    val cashItemEquipmentPresets: List<List<CharacterCashItemInfo>>,
+    val additionalCashItemEquipmentBase: List<CharacterCashItemInfo>,
+    val additionalCashItemEquipmentPresets: List<List<CharacterCashItemInfo>>
+)

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterCashItemColoringPrism.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterCashItemColoringPrism.kt
@@ -1,0 +1,11 @@
+package com.bodan.maplecalendar.domain.entity
+
+import androidx.annotation.Keep
+
+@Keep
+data class CharacterCashItemColoringPrism(
+    val colorRange: String,
+    val hue: String,
+    val saturation: String,
+    val value: String
+)

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterCashItemInfo.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterCashItemInfo.kt
@@ -8,11 +8,11 @@ data class CharacterCashItemInfo(
     val cashItemEquipmentSlot: String,
     val cashItemName: String,
     val cashItemIcon: String,
-    val cashItemDescription: String,
+    val cashItemDescription: String?,
     val cashItemOption: List<CharacterCashItemOption>,
-    val dateExpire: String,
-    val dateOptionExpire: String,
-    val cashItemLabel: String,
-    val cashItemColoringPrism: CharacterCashItemColoringPrism,
-    val itemGender: String
+    val dateExpire: String?,
+    val dateOptionExpire: String?,
+    val cashItemLabel: String?,
+    val cashItemColoringPrism: CharacterCashItemColoringPrism?,
+    val itemGender: String?
 )

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterCashItemInfo.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterCashItemInfo.kt
@@ -1,0 +1,18 @@
+package com.bodan.maplecalendar.domain.entity
+
+import androidx.annotation.Keep
+
+@Keep
+data class CharacterCashItemInfo(
+    val cashItemEquipmentPart: String,
+    val cashItemEquipmentSlot: String,
+    val cashItemName: String,
+    val cashItemIcon: String,
+    val cashItemDescription: String,
+    val cashItemOption: List<CharacterCashItemOption>,
+    val dateExpire: String,
+    val dateOptionExpire: String,
+    val cashItemLabel: String,
+    val cashItemColoringPrism: CharacterCashItemColoringPrism,
+    val itemGender: String
+)

--- a/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterCashItemOption.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/entity/CharacterCashItemOption.kt
@@ -1,0 +1,9 @@
+package com.bodan.maplecalendar.domain.entity
+
+import androidx.annotation.Keep
+
+@Keep
+data class CharacterCashItemOption(
+    val optionType: String,
+    val optionValue: String
+)

--- a/app/src/main/java/com/bodan/maplecalendar/domain/repository/MaplestoryRepository.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/repository/MaplestoryRepository.kt
@@ -5,6 +5,7 @@ import com.bodan.maplecalendar.domain.entity.CharacterAndroid
 import com.bodan.maplecalendar.domain.entity.CharacterDojang
 import com.bodan.maplecalendar.domain.entity.CharacterItemEquipment
 import com.bodan.maplecalendar.domain.entity.CharacterBasic
+import com.bodan.maplecalendar.domain.entity.CharacterCashItem
 import com.bodan.maplecalendar.domain.entity.CharacterHyperStat
 import com.bodan.maplecalendar.domain.entity.CharacterLinkSkill
 import com.bodan.maplecalendar.domain.entity.CharacterOcid
@@ -49,4 +50,6 @@ interface MaplestoryRepository {
     ): Result<CharacterLinkSkill>
 
     suspend fun getCharacterAndroid(ocid: String, date: String?): Result<CharacterAndroid>
+
+    suspend fun getCharacterCashItem(ocid: String, date: String?): Result<CharacterCashItem>
 }

--- a/app/src/main/java/com/bodan/maplecalendar/domain/usecase/GetCharacterCashItemUseCase.kt
+++ b/app/src/main/java/com/bodan/maplecalendar/domain/usecase/GetCharacterCashItemUseCase.kt
@@ -1,0 +1,15 @@
+package com.bodan.maplecalendar.domain.usecase
+
+import com.bodan.maplecalendar.domain.entity.CharacterCashItem
+import com.bodan.maplecalendar.domain.entity.Result
+import com.bodan.maplecalendar.domain.repository.MaplestoryRepository
+import javax.inject.Inject
+
+class GetCharacterCashItemUseCase @Inject constructor(
+    private val maplestoryRepository: MaplestoryRepository
+) {
+
+    suspend fun getCharacterCashItem(ocid: String, date: String?): Result<CharacterCashItem> {
+        return maplestoryRepository.getCharacterCashItem(ocid, date)
+    }
+}


### PR DESCRIPTION
# 2024. 06. 18
## 💭 Motivation
#### 캐시 아이템 데이터를 받아오고자 하였다.

## 🔧 Changed
 - 기본 캐시 장비 아이템과, 3개의 캐시 장비 프리셋을 가져왔다.
 - 제로와 엔젤릭버스터는 기본 캐시 장비 아이템 및 3개의 캐시 장비 프리셋 데이터가 추가적으로 존재한다.

## 📝 To-Do
 - EquipmentFragment에 TabLayout, ViewPager2를 추가하여 장비 아이템과 캐시 장비 아이템을 좌우 스와이프로 확인할 수 있도록 View를 배치한다.
   - 장비 Fragment에는 5 X 6의 크기를 가지는 RecyclerView와 프리셋 변경 버튼이 존재한다.
   - 캐시 장비 Fragment에는 기본 캐시 아이템, 5 X 6의 크기를 가지는 RecyclerView, 프리셋 변경 버튼이 존재한다.
     - 다만 제로와 엔젤릭버스터는 추가적으로 기본 캐시 아이템, 5 X 6의 크기를 가지는 RecyclerView, 프리셋 변경 버튼 View를 배치하여야 한다.

## ✅ Results
<p>
    <img src="https://github.com/littlesam95/MapleCalendar/assets/55424662/6a16027e-e1d9-4cb8-9596-c6a6fce6086b">
</p>